### PR TITLE
Add docs and expand test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,37 +12,106 @@
 5. **Always create a PR** against `main` when work is ready for review
 6. **The developer manually reviews and merges** all PRs — never merge yourself
 
+## Project Overview
+
+Claude Code plugin that monitors GitHub repos and Algora for open bounty issues, sends Telegram notifications, and provides an AI-assisted `/claim` workflow to investigate codebases and draft proposals.
+
+Two modes of operation:
+- **Background monitor** (no AI): standalone Node.js script run by launchd, polls APIs on a timer
+- **Interactive claiming** (AI-assisted): `/claim <url>` fetches issue, clones repo, runs investigation agent, drafts proposal
+
+## Tech Stack
+
+- **TypeScript ESM** (`"type": "module"`, target ES2022, strict mode)
+- **Node.js 20+** runtime
+- **vitest** for testing
+- **yaml** package for config parsing (only runtime dependency)
+- **GitHub CLI (`gh`)** for GitHub API access (no token management needed)
+- **Telegram Bot API** for notifications
+- **Algora tRPC API** for bounty discovery (public, no auth)
+- **macOS launchd** for background scheduling
+
 ## Project Setup
 
-- **TypeScript ESM** project (`"type": "module"` in package.json)
-- All imports **must** use `.js` extensions (e.g., `import { foo } from "./bar.js"`)
-- **vitest** for testing: `npx vitest run`
-- **Build:** `npm run build` (compiles to `dist/`)
-
-## Security
-
-- Use `execFileSync`/`execFile` instead of `execSync`/`exec` to prevent shell injection
-- Never interpolate user input into shell commands
-- Use array-based arguments for all subprocess calls
+```bash
+npm install
+npm run build    # Compile TypeScript to dist/
+npx vitest run   # Run all tests (32 tests across 8 files)
+```
 
 ## Architecture
 
-- `src/` — TypeScript CLI source (GitHub, Algora, Telegram API clients, config parser)
-- `commands/` — Claude Code slash commands (`/hunt`, `/claim`, `/watchlist`)
-- `agents/` — Specialized subagents (issue-investigator)
-- `templates/` — Per-repo proposal templates (Expensify format, default)
+```
+src/
+  types.ts               Shared interfaces (BountyIssue, WatchlistConfig, SeenIssue, etc.)
+  config.ts              YAML config loader, data dir management (~/.bounty-hunter/)
+  seen.ts                SeenStore — JSON-backed deduplication (seen.json)
+  github.ts              GitHub issue fetcher (wraps gh CLI via execFileSync)
+  algora.ts              Algora tRPC client (public API, amounts in cents)
+  telegram.ts            Telegram Bot API client (send messages, get updates)
+  monitor.ts             Background polling loop + pre-filter logic
+  index.ts               CLI entry point (scan, notify, post-comment, seen, config)
+  install-launchd.ts     macOS launchd plist generator and installer
+
+commands/                Claude Code slash commands
+  hunt.md                /hunt — scan for bounties
+  claim.md               /claim <url> — investigate + draft proposal
+  watchlist.md           /watchlist — manage config, first-time setup
+
+agents/
+  issue-investigator.md  Codebase exploration agent (grep, read, trace)
+
+templates/
+  expensify.md           Expensify proposal format (4 required sections, no code diffs)
+  default.md             Generic proposal format
+```
 
 ## Key Patterns
 
-- CLI outputs JSON via `--json` flag for commands/agents to consume
-- State stored in `~/.bounty-hunter/` (watchlist.yml, seen.json, proposals/, clones/)
-- Background monitor is a standalone Node script run by launchd — no AI, just API polling
-- AI only runs interactively when user triggers `/claim`
+- **CLI outputs JSON** via `--json` flag for commands/agents to consume
+- **State stored in** `~/.bounty-hunter/` (watchlist.yml, seen.json, proposals/, clones/)
+- **Background monitor is standalone** — no AI, just API polling + Telegram notifications
+- **AI only runs interactively** when user triggers `/claim`
+- **All imports use `.js` extensions** (ESM requirement): `import { foo } from "./bar.js"`
+- **ESM entry point guard**: `fileURLToPath(import.meta.url) === resolve(process.argv[1])`
+- **Algora amounts are in cents** — divide by 100 for display/filtering
+- **SeenStore uses composite IDs**: `repo#number` format (e.g., `Expensify/App#81500`)
+
+## Security Rules
+
+- **Always use `execFileSync`/`execFile`** with array arguments — never `execSync`/`exec`
+- **Never interpolate user input** into shell commands
+- **Escape XML content** in plist generation (`escapeXml` function in install-launchd.ts)
+- **No secrets in source** — credentials load from runtime config only
+
+## Core Types (src/types.ts)
+
+- `BountyIssue` — normalized issue from GitHub or Algora (source, repo, number, title, url, bounty_amount, labels, body)
+- `WatchlistConfig` — top-level config shape (polling_interval, telegram, sources)
+- `RepoSource` — individual GitHub repo config (name, labels, proposal_template, pre_filter)
+- `AlgoraSource` — Algora config (enabled, min_bounty, languages, keywords_exclude)
+- `SeenIssue` — deduplication record (id, repo, number, title, seen_at, skipped)
+- `TelegramConfig` — bot_token + chat_id
+
+## Data Flow
+
+1. `config.ts` loads `~/.bounty-hunter/watchlist.yml` → `WatchlistConfig`
+2. `monitor.ts` iterates repos: `fetchRepoIssues()` → `applyPreFilter()` → `seen.hasSeen()` → `seen.markSeenFromBounty()`
+3. `monitor.ts` polls Algora: `fetchAlgoraBounties(buildAlgoraFilters())` → `seen.hasSeen()` → `seen.markSeenFromBounty()`
+4. New issues → `formatBountyNotification()` → `sendTelegramMessage()`
+
+## Testing
+
+- Tests live alongside source as `*.test.ts`
+- 32 tests across 8 files
+- Integration test (`integration.test.ts`) hits real GitHub API via `gh` — requires `gh auth status`
+- Integration test overrides `HOME` to isolate config; preserves `GH_CONFIG_DIR` for auth
+- Run: `npx vitest run` (all tests) or `npx vitest run src/github.test.ts` (single file)
 
 ## CLI Commands
 
 - `bounty-hunter scan [--json]` — poll watchlist, return issues
 - `bounty-hunter notify <issue-json>` — send Telegram notification
-- `bounty-hunter post-comment --repo <repo> --issue <num> --body <file>` — post proposal to GitHub
+- `bounty-hunter post-comment --repo <repo> --issue <num> --body <file>` — post proposal
 - `bounty-hunter seen --add <repo>#<number>` — mark issue as seen
 - `bounty-hunter config` — output current watchlist config as JSON

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to Bounty Hunter
+
+## Getting Started
+
+```bash
+git clone https://github.com/costajohnt/bounty-hunter.git
+cd bounty-hunter
+npm install
+npm run build
+npx vitest run
+```
+
+You need Node.js 20+ and the GitHub CLI (`gh`) authenticated for integration tests.
+
+## Development Workflow
+
+1. Always branch off `main`:
+   ```bash
+   git checkout main && git pull origin main
+   git checkout -b your-branch-name
+   ```
+2. Write tests before implementation. Every new exported function needs a test.
+3. Build and run the full test suite before pushing:
+   ```bash
+   npm run build && npx vitest run
+   ```
+4. Open a PR against `main`. Never commit directly to `main`.
+
+### Commit Conventions
+
+Use clear, imperative commit messages:
+
+```
+add algora API pagination support
+fix telegram notification escaping
+refactor config loader to use yaml.parse
+```
+
+No prefix tags, no capitalized first word, no trailing period.
+
+## Code Style
+
+This is a **TypeScript ESM** project (`"type": "module"` in package.json).
+
+- All imports **must** use `.js` extensions:
+  ```typescript
+  import { loadConfig } from "./config.js";
+  ```
+- Target is ES2022 with strict mode enabled.
+- Use `execFileSync` (or `execFile`) with array arguments for all subprocess calls. Never use `execSync` or `exec`.
+- Keep modules focused. Each source file in `src/` covers a single concern (GitHub client, Algora client, Telegram client, config, monitor, etc.).
+
+## Testing
+
+Tests use **vitest** and live alongside source files as `*.test.ts`.
+
+```bash
+# Run all tests
+npx vitest run
+
+# Run a specific test file
+npx vitest run src/github.test.ts
+
+# Watch mode during development
+npx vitest
+```
+
+**What needs tests:**
+
+- Any new exported function.
+- Any bug fix (add a regression test).
+- Any change to CLI output format.
+
+**Integration tests** (`src/integration.test.ts`) hit the real GitHub API and require `gh auth status` to pass. These run as part of the normal test suite. If you do not have `gh` authenticated, they will fail.
+
+## Security
+
+These rules are non-negotiable:
+
+1. **Never use `exec` or `execSync`.** Always use `execFileSync` (or `execFile`) with arguments as an array:
+   ```typescript
+   // correct
+   execFileSync("gh", ["issue", "list", "--repo", repo, "--json", "title"]);
+
+   // wrong -- shell injection risk
+   execSync(`gh issue list --repo ${repo} --json title`);
+   ```
+2. **Never interpolate user input into commands.** Pass user-provided values as discrete array elements.
+3. **Escape XML/plist content.** When generating launchd plist files, escape all dynamic values (`&`, `<`, `>`, `"`, `'`) to prevent XML injection.
+
+## Pull Requests
+
+- **Branch naming:** descriptive kebab-case (`add-algora-pagination`, `fix-telegram-escaping`).
+- **PR description:** explain what changed and why. Include test output if relevant.
+- **Tests must pass.** PRs with failing tests will not be reviewed.
+- **Squash merge preferred.** Keep `main` history clean.
+- The maintainer reviews and merges all PRs. Do not merge your own.
+
+## Project Architecture
+
+```
+src/                 TypeScript CLI source
+  index.ts           CLI entry point
+  github.ts          GitHub API client (uses gh CLI)
+  algora.ts          Algora bounty API client
+  telegram.ts        Telegram notification client
+  config.ts          Watchlist config loader (~/.bounty-hunter/watchlist.yml)
+  monitor.ts         Background polling logic (no AI, just API calls)
+  seen.ts            Tracks seen issues (~/.bounty-hunter/seen.json)
+  install-launchd.ts macOS launchd plist generator
+  types.ts           Shared type definitions
+
+commands/            Claude Code slash commands
+  hunt.md            /hunt -- scan for new bounty issues
+  claim.md           /claim -- investigate and draft a proposal
+  watchlist.md       /watchlist -- manage watched repos
+
+agents/              Claude Code subagents
+  issue-investigator.md   Analyzes an issue and drafts a proposal
+
+templates/           Per-repo proposal templates
+  default.md         Generic proposal format
+  expensify.md       Expensify-specific proposal format
+```
+
+The CLI outputs JSON via `--json` for slash commands and agents to consume. State is stored in `~/.bounty-hunter/`. The background monitor is a standalone Node script run by launchd -- it does no AI work, only API polling and Telegram notifications. AI runs only when a user triggers `/claim` interactively.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 John Costa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,381 @@
+# Bounty Hunter
+
+A [Claude Code](https://docs.anthropic.com/en/docs/claude-code) plugin that monitors GitHub repos and [Algora](https://algora.io) for open bounty issues, sends Telegram push notifications when new bounties appear, and provides an interactive `/claim` workflow to investigate codebases and draft proposals with AI assistance.
+
+## Table of Contents
+
+- [Why Bounty Hunter?](#why-bounty-hunter)
+- [How It Works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
+  - [Plugin Commands](#plugin-commands)
+  - [CLI Commands](#cli-commands)
+- [Background Monitor](#background-monitor)
+- [Proposal Templates](#proposal-templates)
+- [Architecture](#architecture)
+- [Development](#development)
+- [License](#license)
+
+## Why Bounty Hunter?
+
+Open-source bounty issues are competitive. The first adequate proposal often wins. The two biggest bottlenecks for contributors are:
+
+1. **Time to awareness** -- By the time you manually check a repo, scroll through labels, and find a new bounty, someone else has already claimed it. Hours or even minutes matter.
+
+2. **Time to investigation** -- Understanding an unfamiliar codebase well enough to write a credible proposal takes time. Cloning, grepping, tracing execution paths, reading contributing guidelines -- it adds up.
+
+Bounty Hunter attacks both bottlenecks. A lightweight background monitor polls your watchlist and sends Telegram notifications the moment a new bounty appears -- no AI, no heavy compute, just API calls on a timer. When you are ready to act, the `/claim` command clones the repo, launches an AI-powered investigation agent to explore the code, and drafts a proposal in the format the project expects. You review, edit if needed, and post -- all without leaving Claude Code.
+
+## How It Works
+
+The plugin operates in two distinct modes:
+
+**Background monitoring (no AI):** A standalone Node.js script runs on a timer via macOS launchd. It polls GitHub (via `gh` CLI) and the Algora tRPC API for issues matching your watchlist criteria, deduplicates against previously seen issues, and sends Telegram notifications for anything new.
+
+**Interactive claiming (AI-assisted):** When you run `/claim <issue-url>` inside Claude Code, the plugin fetches the full issue, assesses competition from existing proposals, clones or updates the repository, launches an investigation agent to explore the codebase, drafts a proposal using the appropriate template, and presents it for your review before posting.
+
+```
+  Telegram notification arrives
+         |
+         v
+  You open Claude Code
+         |
+         v
+  /claim https://github.com/org/repo/issues/123
+         |
+         v
+  Fetch issue --> Assess competition --> Clone repo
+         |
+         v
+  AI investigates codebase (grep, read, trace)
+         |
+         v
+  Draft proposal using repo's template
+         |
+         v
+  Review --> Approve / Edit / Save / Discard
+         |
+         v
+  Post comment on GitHub issue
+```
+
+## Prerequisites
+
+- **Node.js 20+**
+- **GitHub CLI** (`gh`) -- [install](https://cli.github.com/) and authenticate with `gh auth login`
+- **Claude Code CLI** -- [install](https://docs.anthropic.com/en/docs/claude-code)
+- **Telegram bot** -- created via [@BotFather](https://t.me/BotFather) (takes about 60 seconds)
+
+## Installation
+
+Clone the repository and build:
+
+```bash
+git clone https://github.com/costajohnt/bounty-hunter.git
+cd bounty-hunter
+npm install
+npm run build
+```
+
+Register the plugin with Claude Code:
+
+```bash
+claude plugin add /path/to/bounty-hunter
+```
+
+Then open Claude Code and run `/watchlist` to start the interactive setup wizard.
+
+## Configuration
+
+All state is stored in `~/.bounty-hunter/`:
+
+```
+~/.bounty-hunter/
+  watchlist.yml     # Your configuration (repos, labels, Telegram, Algora)
+  seen.json         # Deduplication store for already-seen issues
+  proposals/        # Saved proposal drafts
+  clones/           # Shallow repo clones (cached)
+```
+
+### Watchlist Format
+
+The watchlist lives at `~/.bounty-hunter/watchlist.yml`. You can edit it by hand or use the `/watchlist` command inside Claude Code.
+
+```yaml
+polling_interval: 5  # minutes
+
+telegram:
+  bot_token: "123456:ABC-DEF..."
+  chat_id: "987654321"
+
+sources:
+  repos:
+    - name: Expensify/App
+      labels: ["Help Wanted"]
+      proposal_template: expensify
+      pre_filter:
+        keywords_exclude: ["Android", "iOS native"]
+
+    - name: tenstorrent/tt-mlir
+      labels: ["bounty"]
+      proposal_template: auto
+
+  algora:
+    enabled: true
+    min_bounty: 50        # USD, filters out small bounties
+    languages: []          # empty = all languages
+    keywords_exclude: []   # exclude issues containing these terms
+```
+
+### Configuration Fields
+
+| Field | Description |
+|---|---|
+| `polling_interval` | How often the background monitor checks for new issues, in minutes |
+| `telegram.bot_token` | Token from @BotFather |
+| `telegram.chat_id` | Your Telegram chat ID (the setup wizard helps you find this) |
+| `sources.repos[].name` | GitHub repo in `owner/repo` format |
+| `sources.repos[].labels` | Only match issues with these labels |
+| `sources.repos[].proposal_template` | Which template to use: `expensify`, `default`, or `auto` |
+| `sources.repos[].pre_filter.keywords_exclude` | Skip issues whose title or body contains these keywords |
+| `sources.algora.enabled` | Whether to poll Algora for bounties |
+| `sources.algora.min_bounty` | Minimum bounty amount in USD (Algora amounts are in cents internally) |
+| `sources.algora.languages` | Only match bounties tagged with these languages (empty = all) |
+| `sources.algora.keywords_exclude` | Skip Algora bounties containing these keywords |
+
+### Telegram Setup
+
+If you do not have a Telegram bot yet, the `/watchlist` command walks you through it. The short version:
+
+1. Open Telegram and search for **@BotFather**
+2. Send `/newbot`, choose a name and username
+3. Copy the bot token BotFather gives you
+4. Send any message to your new bot
+5. Run `curl -s "https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates"` and find your `chat.id` in the response
+
+## Usage
+
+### Plugin Commands
+
+These are the slash commands available inside Claude Code after installing the plugin:
+
+#### /hunt -- Scan for Bounties
+
+Scans your entire watchlist and displays a formatted table of bounty issues. New (unseen) issues are highlighted. Issues with zero existing proposals are called out as the best opportunities.
+
+```
+/hunt
+```
+
+#### /claim -- Investigate and Draft a Proposal
+
+The core workflow. Give it a GitHub issue URL and it handles the rest:
+
+```
+/claim https://github.com/Expensify/App/issues/81500
+```
+
+What happens:
+
+1. Fetches the issue body, comments, and labels via `gh`
+2. Assesses competition (counts existing proposals, summarizes them)
+3. Clones or updates the repo (shallow clone, cached in `~/.bounty-hunter/clones/`)
+4. Launches the issue-investigator agent to explore the codebase -- reads files mentioned in the issue, searches for relevant code, traces execution paths, identifies root cause or implementation location
+5. Drafts a proposal using the appropriate template for the repo
+6. Presents the draft for your review with four options:
+   - **Approve** -- posts the proposal as a GitHub comment
+   - **Edit** -- modify the text, then re-review
+   - **Save for later** -- writes to `~/.bounty-hunter/proposals/` without posting
+   - **Discard** -- skip this issue
+
+#### /watchlist -- Manage Configuration
+
+View, modify, or test your watchlist configuration:
+
+```
+/watchlist              # Show current configuration
+/watchlist add <repo>   # Add a repo to the watchlist
+/watchlist remove <repo># Remove a repo
+/watchlist test         # Run a test scan without marking anything as seen
+```
+
+On first run (when no config file exists), `/watchlist` enters an interactive setup wizard that walks you through Telegram bot creation, repo selection, label configuration, and Algora settings.
+
+### CLI Commands
+
+The CLI is used internally by the plugin commands but can also be invoked directly for scripting or debugging:
+
+```bash
+# Scan the watchlist and display results
+bounty-hunter scan
+bounty-hunter scan --json
+
+# Send a Telegram notification for an issue
+bounty-hunter notify '<issue-json>'
+
+# Post a proposal as a GitHub comment
+bounty-hunter post-comment --repo owner/repo --issue 123 --body proposal.md
+
+# Mark an issue as seen (skip future notifications)
+bounty-hunter seen --add owner/repo#123
+
+# Output current watchlist config as JSON
+bounty-hunter config
+```
+
+## Background Monitor
+
+The background monitor is a standalone Node.js script that runs without AI. It polls GitHub and Algora on a timer, checks for new issues against the seen store, and sends Telegram notifications for anything new.
+
+On macOS, it runs as a launchd agent that fires every N minutes (matching your `polling_interval` setting).
+
+### Install the Monitor
+
+```bash
+node dist/install-launchd.js install
+```
+
+This creates a launchd plist at `~/Library/LaunchAgents/com.bounty-hunter.monitor.plist`, loads it immediately, and starts polling. The monitor runs at login and on the configured interval.
+
+### Uninstall the Monitor
+
+```bash
+node dist/install-launchd.js uninstall
+```
+
+### Logs
+
+Monitor output is written to:
+
+```
+~/.bounty-hunter/monitor.log
+```
+
+### How It Differs from /hunt
+
+The background monitor and `/hunt` serve different purposes:
+
+| | Background Monitor | /hunt |
+|---|---|---|
+| Runs | Automatically on a timer | On demand, inside Claude Code |
+| AI | None | None (but leads into `/claim`) |
+| Output | Telegram push notifications | Formatted table in Claude Code |
+| Marks seen | Yes (prevents duplicate notifications) | No (read-only view) |
+
+## Proposal Templates
+
+Bounty Hunter ships with two built-in proposal templates and an `auto` mode:
+
+### expensify
+
+Follows Expensify's strict proposal format with four required sections. Does **not** include code diffs (Expensify forbids them in proposals).
+
+```markdown
+### Please re-state the problem that we are trying to solve in this issue.
+### What is the root cause of that problem?
+### What changes do you think we should make in order to solve the problem?
+### What alternative solutions did you explore? (Optional)
+```
+
+### default
+
+A generic format suitable for most projects:
+
+```markdown
+**Problem:** ...
+**Root Cause:** ...
+**Proposed Changes:** ...
+**Testing:** ...
+```
+
+### auto
+
+When set to `auto`, the `/claim` command checks the target repo's `CONTRIBUTING.md` for proposal format guidance and adapts accordingly.
+
+### Custom Templates
+
+You can add your own templates by placing Markdown files in the `templates/` directory of the plugin. Reference them by filename (without extension) in your watchlist config.
+
+## Architecture
+
+```
+bounty-hunter/
+├── .claude-plugin/
+│   └── plugin.json            # Plugin manifest (name, description, metadata)
+├── src/
+│   ├── types.ts               # Core interfaces (BountyIssue, WatchlistConfig, etc.)
+│   ├── config.ts              # YAML config loader, data directory management
+│   ├── seen.ts                # SeenStore — JSON-backed deduplication
+│   ├── github.ts              # GitHub issue fetcher (wraps gh CLI via execFileSync)
+│   ├── algora.ts              # Algora tRPC client (public API, no auth needed)
+│   ├── telegram.ts            # Telegram Bot API (send messages, get updates)
+│   ├── monitor.ts             # Background polling loop + pre-filter logic
+│   ├── index.ts               # CLI entry point (scan, notify, post-comment, seen, config)
+│   └── install-launchd.ts     # macOS launchd plist generator and installer
+├── commands/
+│   ├── hunt.md                # /hunt — scan for bounties
+│   ├── claim.md               # /claim <url> — investigate + draft proposal
+│   └── watchlist.md           # /watchlist — manage config, first-time setup
+├── agents/
+│   └── issue-investigator.md  # Codebase exploration agent (grep, read, trace)
+└── templates/
+    ├── expensify.md           # Expensify proposal format
+    └── default.md             # Generic proposal format
+```
+
+### Design Decisions
+
+- **`gh` CLI over GitHub API:** Uses the GitHub CLI instead of direct API calls. This avoids token management entirely -- if `gh` is authenticated, everything works.
+- **`execFileSync` over `execSync`:** All subprocess calls use `execFileSync` with array arguments to prevent shell injection.
+- **No AI in the monitor:** The background process does zero AI inference. It is pure API polling and notification logic. This keeps it fast, cheap, and predictable.
+- **Shallow clones:** Repos are cloned with `--depth 50` and cached in `~/.bounty-hunter/clones/`. Subsequent runs fetch and checkout rather than re-cloning.
+- **Algora amounts in cents:** The Algora API returns bounty amounts in cents. The plugin converts to dollars for display and filtering.
+
+## Development
+
+### Setup
+
+```bash
+git clone https://github.com/costajohnt/bounty-hunter.git
+cd bounty-hunter
+npm install
+```
+
+### Build
+
+```bash
+npm run build       # Compile TypeScript to dist/
+npm run dev         # Watch mode — recompiles on file changes
+```
+
+### Test
+
+The test suite includes 22 tests across 7 test files covering config loading, seen store persistence, pre-filter logic, GitHub argument building, Algora response parsing, Telegram formatting, and CLI integration.
+
+```bash
+npx vitest run      # Run all tests once
+npx vitest          # Watch mode
+```
+
+### Project Conventions
+
+- **TypeScript ESM** -- the project uses `"type": "module"` in package.json
+- All imports must use `.js` extensions (e.g., `import { foo } from "./bar.js"`)
+- `vitest` for testing
+- Strict TypeScript (`"strict": true`)
+
+### Dependencies
+
+The project has a single runtime dependency:
+
+| Package | Purpose |
+|---|---|
+| `yaml` | Parse `watchlist.yml` configuration |
+
+Dev dependencies: `typescript`, `@types/node`, `vitest`.
+
+## License
+
+MIT

--- a/src/algora.test.ts
+++ b/src/algora.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { buildAlgoraUrl, parseAlgoraResponse } from "./algora.js";
+import { buildAlgoraUrl, parseAlgoraResponse, buildAlgoraFilters } from "./algora.js";
+import type { AlgoraSource } from "./types.js";
 
 describe("buildAlgoraUrl", () => {
   it("builds URL with default params", () => {
@@ -81,5 +82,99 @@ describe("parseAlgoraResponse", () => {
     const issues = parseAlgoraResponse(raw, { min_bounty: 100 });
     expect(issues).toHaveLength(1);
     expect(issues[0].title).toBe("Big");
+  });
+
+  it("filters by keywords_exclude in title", () => {
+    const raw = [{
+      result: {
+        data: {
+          json: {
+            items: [
+              {
+                id: "a", status: "open",
+                reward: { currency: "USD", amount: 10000 },
+                reward_formatted: "$100",
+                tech: [], created_at: "2026-02-05T00:00:00Z",
+                task: { number: 1, title: "Fix devops pipeline", url: "https://github.com/t/r/issues/1", body: "Some body", repo_name: "r", repo_owner: "t" },
+                org: { handle: "t", name: "T" },
+              },
+              {
+                id: "b", status: "open",
+                reward: { currency: "USD", amount: 20000 },
+                reward_formatted: "$200",
+                tech: [], created_at: "2026-02-05T00:00:00Z",
+                task: { number: 2, title: "Add new feature", url: "https://github.com/t/r/issues/2", body: "Feature description", repo_name: "r", repo_owner: "t" },
+                org: { handle: "t", name: "T" },
+              },
+            ],
+            next_cursor: null,
+          },
+        },
+      },
+    }];
+    const issues = parseAlgoraResponse(raw, { keywords_exclude: ["devops"] });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].title).toBe("Add new feature");
+  });
+
+  it("filters by keywords_exclude in body", () => {
+    const raw = [{
+      result: {
+        data: {
+          json: {
+            items: [
+              {
+                id: "a", status: "open",
+                reward: { currency: "USD", amount: 10000 },
+                reward_formatted: "$100",
+                tech: [], created_at: "2026-02-05T00:00:00Z",
+                task: { number: 1, title: "Fix issue", url: "https://github.com/t/r/issues/1", body: "This involves Kubernetes orchestration", repo_name: "r", repo_owner: "t" },
+                org: { handle: "t", name: "T" },
+              },
+              {
+                id: "b", status: "open",
+                reward: { currency: "USD", amount: 20000 },
+                reward_formatted: "$200",
+                tech: [], created_at: "2026-02-05T00:00:00Z",
+                task: { number: 2, title: "Another issue", url: "https://github.com/t/r/issues/2", body: "Simple frontend fix", repo_name: "r", repo_owner: "t" },
+                org: { handle: "t", name: "T" },
+              },
+            ],
+            next_cursor: null,
+          },
+        },
+      },
+    }];
+    const issues = parseAlgoraResponse(raw, { keywords_exclude: ["kubernetes"] });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].title).toBe("Another issue");
+  });
+});
+
+describe("buildAlgoraFilters", () => {
+  it("converts AlgoraSource to filter params correctly", () => {
+    const source: AlgoraSource = {
+      enabled: true,
+      min_bounty: 100,
+      languages: ["typescript", "rust"],
+      keywords_exclude: ["devops", "infra"],
+    };
+    const filters = buildAlgoraFilters(source);
+    expect(filters.min_bounty).toBe(100);
+    expect(filters.languages).toEqual(["typescript", "rust"]);
+    expect(filters.keywords_exclude).toEqual(["devops", "infra"]);
+  });
+
+  it("converts empty languages array to undefined", () => {
+    const source: AlgoraSource = {
+      enabled: true,
+      min_bounty: 50,
+      languages: [],
+      keywords_exclude: [],
+    };
+    const filters = buildAlgoraFilters(source);
+    expect(filters.min_bounty).toBe(50);
+    expect(filters.languages).toBeUndefined();
+    expect(filters.keywords_exclude).toEqual([]);
   });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -25,4 +25,14 @@ describe("buildSearchArgs", () => {
     expect(args).toContain("Expensify/App");
     expect(args).toContain("Help Wanted");
   });
+
+  it("includes all labels when multiple are provided", () => {
+    const args = buildSearchArgs("Expensify/App", ["Help Wanted", "External", "Bug"]);
+    expect(args).toContain("Help Wanted");
+    expect(args).toContain("External");
+    expect(args).toContain("Bug");
+    // Each label should be preceded by --label
+    const labelFlags = args.reduce((count, arg) => arg === "--label" ? count + 1 : count, 0);
+    expect(labelFlags).toBe(3);
+  });
 });

--- a/src/install-launchd.test.ts
+++ b/src/install-launchd.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { generatePlist } from "./install-launchd.js";
+import { mkdirSync, rmSync } from "node:fs";
+
+const TEST_HOME = "/tmp/bounty-hunter-test-launchd";
+
+describe("generatePlist", () => {
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    process.env.HOME = TEST_HOME;
+    mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it("generates valid XML with correct label, interval, and paths", () => {
+    const plist = generatePlist("/usr/local/bin/monitor.js", 300);
+    expect(plist).toContain("<?xml version=\"1.0\"");
+    expect(plist).toContain("<string>com.bounty-hunter.monitor</string>");
+    expect(plist).toContain("<string>/usr/local/bin/monitor.js</string>");
+    expect(plist).toContain("<integer>300</integer>");
+  });
+
+  it("contains the monitor script path", () => {
+    const plist = generatePlist("/some/path/to/monitor.js", 600);
+    expect(plist).toContain("<string>/some/path/to/monitor.js</string>");
+  });
+
+  it("contains the correct interval", () => {
+    const plist = generatePlist("/path/monitor.js", 120);
+    expect(plist).toContain("<integer>120</integer>");
+  });
+
+  it("escapes XML special characters in paths", () => {
+    const plist = generatePlist("/path/with<special>&chars>here.js", 300);
+    expect(plist).toContain("&amp;");
+    expect(plist).toContain("&lt;");
+    expect(plist).toContain("&gt;");
+    expect(plist).not.toContain("<special>");
+    expect(plist).not.toContain("&chars>");
+  });
+});

--- a/src/seen.test.ts
+++ b/src/seen.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SeenStore } from "./seen.js";
 import { mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import type { BountyIssue } from "./types.js";
 
 const TEST_DIR = "/tmp/bounty-hunter-test-seen";
 
@@ -49,5 +50,23 @@ describe("SeenStore", () => {
   it("marks issues as skipped", () => {
     store.markSkipped("Expensify/App", 81500);
     expect(store.hasSeen("Expensify/App", 81500)).toBe(true);
+  });
+
+  it("marks seen from a BountyIssue", () => {
+    const bountyIssue: BountyIssue = {
+      source: "github",
+      repo: "Expensify/App",
+      number: 99999,
+      title: "Fix performance issue",
+      url: "https://github.com/Expensify/App/issues/99999",
+      bounty_amount: 500,
+      bounty_formatted: "$500",
+      labels: ["Help Wanted"],
+      body: "Performance is slow",
+      comment_count: 3,
+      created_at: "2026-02-05T00:00:00Z",
+    };
+    store.markSeenFromBounty(bountyIssue);
+    expect(store.hasSeen("Expensify/App", 99999)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add comprehensive **README.md** with prerequisites, installation, configuration (watchlist format + Telegram setup), usage for all 3 plugin commands and 5 CLI commands, background monitor docs, proposal templates, architecture tree, and design decisions
- Add **CONTRIBUTING.md** with developer workflow, commit conventions, code style (ESM, execFileSync, single-concern modules), testing guide, security rules, and PR guidelines
- Add **MIT LICENSE**
- Expand **CLAUDE.md** with core types, data flow, testing patterns, and security rules
- Add **10 new unit tests** (22 → 32 total):
  - `install-launchd.test.ts`: plist generation, XML escaping of special characters
  - `algora.test.ts`: `buildAlgoraFilters` helper, keyword exclusion in title and body
  - `github.test.ts`: multiple labels in `buildSearchArgs`
  - `seen.test.ts`: `markSeenFromBounty` convenience method

## Test plan

- [x] `npm run build` — clean compilation
- [x] `npx vitest run` — 32/32 tests passing across 8 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)