### PR TITLE
Fix plugin commands to use $ARGUMENTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ npm install
 npm run build
 ```
 
-Register the plugin with Claude Code:
+Launch Claude Code with the plugin loaded:
 
 ```bash
-claude plugin add /path/to/bounty-hunter
+claude --plugin-dir /path/to/bounty-hunter
 ```
 
-Then open Claude Code and run `/watchlist` to start the interactive setup wizard.
+Then run `/watchlist` to start the interactive setup wizard.
 
 ## Configuration
 

--- a/commands/claim.md
+++ b/commands/claim.md
@@ -1,14 +1,13 @@
 ---
 name: claim
 description: "Investigate a bounty issue and draft a proposal"
+argument-hint: <issue-url>
 allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion, Task, Edit
 ---
 
 You are the bounty hunter claim assistant. The user wants to investigate a GitHub issue and draft a proposal to claim a bounty.
 
-## Arguments
-
-The user provides an issue URL as an argument, e.g., `/claim https://github.com/Expensify/App/issues/81500`
+The issue URL is: $ARGUMENTS
 
 ## Steps
 

--- a/commands/watchlist.md
+++ b/commands/watchlist.md
@@ -1,18 +1,21 @@
 ---
 name: watchlist
 description: "Manage your bounty watchlist — add/remove repos, configure alerts"
+argument-hint: "[add|remove|test] [repo]"
 allowed-tools: Bash, Read, Write, AskUserQuestion
 ---
 
 You are the bounty hunter watchlist manager.
 
+The user's arguments: $ARGUMENTS
+
 ## Subcommands
 
-The user may run:
-- `/watchlist` — show current configuration
-- `/watchlist add <repo>` — add a repo to the watchlist
-- `/watchlist remove <repo>` — remove a repo
-- `/watchlist test` — run a test scan and show what would match
+Based on the arguments above, determine which action to take:
+- No arguments or empty → show current configuration
+- `add <repo>` → add a repo to the watchlist
+- `remove <repo>` → remove a repo
+- `test` → run a test scan and show what would match
 
 ## Config Location
 


### PR DESCRIPTION
## Summary

- **`/claim` command**: Add `argument-hint: <issue-url>` and inject the URL into the prompt via `$ARGUMENTS` so Claude actually receives the issue URL the user typed
- **`/watchlist` command**: Add `argument-hint: "[add|remove|test] [repo]"` and inject `$ARGUMENTS` so subcommands (`add`, `remove`, `test`) and their arguments are passed through
- **README.md**: Fix installation instructions from `claude plugin add` (doesn't exist) to `claude --plugin-dir /path/to/bounty-hunter`

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run` — 32/32 passing
- [ ] Manual: `claude --plugin-dir .` then `/claim https://github.com/Expensify/App/issues/81500` — verify URL appears in prompt
- [ ] Manual: `/watchlist test` — verify "test" is parsed as the subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)