### PR TITLE
Add GitHub Actions cron monitor with Zod config validation

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,0 +1,48 @@
+name: Bounty Monitor
+
+on:
+  schedule:
+    # Every 15 minutes
+    - cron: "*/15 * * * *"
+  workflow_dispatch: # Allow manual triggers
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Prepare data directory
+        run: mkdir -p ~/.bounty-hunter
+
+      - name: Copy watchlist config
+        run: cp watchlist.example.yml ~/.bounty-hunter/watchlist.yml
+
+      - name: Restore seen.json from cache
+        id: seen-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.bounty-hunter/seen.json
+          key: seen-state
+
+      - name: Run monitor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: node dist/monitor.js
+
+      - name: Save seen.json to cache
+        uses: actions/cache/save@v4
+        if: always()
+        with:
+          path: ~/.bounty-hunter/seen.json
+          key: seen-state-${{ github.run_id }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "bounty-hunter",
       "version": "0.1.0",
       "dependencies": {
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.2",
+        "zod": "^4.3.6"
       },
       "bin": {
         "bounty-hunter": "dist/index.js"
@@ -1633,6 +1634,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "monitor": "node dist/monitor.js"
   },
   "dependencies": {
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.2",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -43,6 +43,43 @@ sources:
   it("throws on missing file", () => {
     expect(() => loadConfig(join(TEST_DIR, "nope.yml"))).toThrow();
   });
+
+  it("throws on invalid config shape", () => {
+    const yml = `
+polling_interval: "not-a-number"
+telegram:
+  bot_token: 123
+`;
+    writeFileSync(join(TEST_DIR, "watchlist.yml"), yml);
+    expect(() => loadConfig(join(TEST_DIR, "watchlist.yml"))).toThrow();
+  });
+
+  it("overrides telegram config from env vars", () => {
+    const yml = `
+polling_interval: 5
+telegram:
+  bot_token: "yaml-token"
+  chat_id: "yaml-chat"
+sources:
+  repos: []
+  algora:
+    enabled: false
+    min_bounty: 0
+    languages: []
+    keywords_exclude: []
+`;
+    writeFileSync(join(TEST_DIR, "watchlist.yml"), yml);
+    process.env.TELEGRAM_BOT_TOKEN = "env-token";
+    process.env.TELEGRAM_CHAT_ID = "env-chat";
+    try {
+      const config = loadConfig(join(TEST_DIR, "watchlist.yml"));
+      expect(config.telegram.bot_token).toBe("env-token");
+      expect(config.telegram.chat_id).toBe("env-chat");
+    } finally {
+      delete process.env.TELEGRAM_BOT_TOKEN;
+      delete process.env.TELEGRAM_CHAT_ID;
+    }
+  });
 });
 
 describe("ensureDataDir", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { parse } from "yaml";
+import { WatchlistConfigSchema } from "./types.js";
 import type { WatchlistConfig } from "./types.js";
 
 export function getDataDir(): string {
@@ -17,7 +18,16 @@ export function loadConfig(path?: string): WatchlistConfig {
     throw new Error(`Config not found: ${configPath}. Run /watchlist to set up.`);
   }
   const raw = readFileSync(configPath, "utf-8");
-  return parse(raw) as WatchlistConfig;
+  const parsed = parse(raw);
+
+  // Allow env vars to override Telegram secrets (for CI/GitHub Actions)
+  if (process.env.TELEGRAM_BOT_TOKEN || process.env.TELEGRAM_CHAT_ID) {
+    parsed.telegram = parsed.telegram ?? {};
+    if (process.env.TELEGRAM_BOT_TOKEN) parsed.telegram.bot_token = process.env.TELEGRAM_BOT_TOKEN;
+    if (process.env.TELEGRAM_CHAT_ID) parsed.telegram.chat_id = process.env.TELEGRAM_CHAT_ID;
+  }
+
+  return WatchlistConfigSchema.parse(parsed);
 }
 
 export function ensureDataDir(baseDir?: string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,32 +1,46 @@
-export interface RepoSource {
-  name: string;
-  labels: string[];
-  proposal_template: string;
-  pre_filter?: {
-    keywords_exclude?: string[];
-  };
-}
+import { z } from "zod";
 
-export interface AlgoraSource {
-  enabled: boolean;
-  min_bounty: number;
-  languages: string[];
-  keywords_exclude: string[];
-}
+// --- Config schemas (Zod = single source of truth) ---
 
-export interface TelegramConfig {
-  bot_token: string;
-  chat_id: string;
-}
+const RepoSourceSchema = z.object({
+  name: z.string(),
+  labels: z.array(z.string()),
+  proposal_template: z.string(),
+  pre_filter: z
+    .object({
+      keywords_exclude: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
 
-export interface WatchlistConfig {
-  polling_interval: number;
-  telegram: TelegramConfig;
-  sources: {
-    repos: RepoSource[];
-    algora: AlgoraSource;
-  };
-}
+const AlgoraSourceSchema = z.object({
+  enabled: z.boolean(),
+  min_bounty: z.number(),
+  languages: z.array(z.string()),
+  keywords_exclude: z.array(z.string()),
+});
+
+const TelegramConfigSchema = z.object({
+  bot_token: z.string(),
+  chat_id: z.string(),
+});
+
+export const WatchlistConfigSchema = z.object({
+  polling_interval: z.number(),
+  telegram: TelegramConfigSchema,
+  sources: z.object({
+    repos: z.array(RepoSourceSchema),
+    algora: AlgoraSourceSchema,
+  }),
+});
+
+// Derive types from schemas
+export type RepoSource = z.infer<typeof RepoSourceSchema>;
+export type AlgoraSource = z.infer<typeof AlgoraSourceSchema>;
+export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
+export type WatchlistConfig = z.infer<typeof WatchlistConfigSchema>;
+
+// --- Non-config types (plain interfaces) ---
 
 export interface SeenIssue {
   id: string;

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -1,0 +1,27 @@
+# Bounty Hunter Watchlist Configuration
+#
+# Edit this file to add/remove repos and bounty sources.
+# Telegram secrets are injected from environment variables at runtime
+# (TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID) — the values below are placeholders.
+
+polling_interval: 15
+
+telegram:
+  bot_token: "set-via-env"
+  chat_id: "set-via-env"
+
+sources:
+  repos:
+    - name: Expensify/App
+      labels:
+        - "Help Wanted"
+      proposal_template: expensify
+      pre_filter:
+        keywords_exclude:
+          - "NewDot"
+
+  algora:
+    enabled: true
+    min_bounty: 50
+    languages: []
+    keywords_exclude: []


### PR DESCRIPTION
## Summary

- **GitHub Actions cron workflow** (`.github/workflows/monitor.yml`) runs the bounty monitor every 15 minutes in the cloud, replacing the need for a local macOS launchd setup
- **Zod schema validation** replaces the `as WatchlistConfig` typecast in `loadConfig()` — config is now validated at runtime with clear error messages on malformed YAML
- **Env var overrides** for Telegram secrets (`TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`) so credentials stay out of the config file and are injected from GitHub Secrets

## Details

| File | Change |
|------|--------|
| `src/types.ts` | Config interfaces → Zod schemas with `z.infer<>` derived types |
| `src/config.ts` | `WatchlistConfigSchema.parse()` replaces typecast; env var overrides with null-safety guard |
| `src/config.test.ts` | +2 tests: env var override, invalid config rejection |
| `watchlist.example.yml` | User-editable config template (placeholder telegram values) |
| `.github/workflows/monitor.yml` | 15-min cron + manual dispatch, split cache restore/save for `seen.json` |

## Setup (after merge)

1. Create a Telegram bot via @BotFather, get the bot token
2. Message the bot, get your `chat_id`
3. Add GitHub Secrets: `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
4. Edit `watchlist.example.yml` with your watched repos/labels, push to main
5. Manually trigger the workflow to test, then let the cron take over

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npx vitest run` — all 33 unit tests pass (integration test excluded due to GitHub API rate limit)
- [x] New test validates Zod rejects malformed config
- [x] New test validates env vars override YAML telegram values
- [ ] Manual workflow dispatch on GitHub to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)