### PR TITLE
Add issue vetting system for deeper bounty filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Two modes of operation:
 ```bash
 npm install
 npm run build    # Compile TypeScript to dist/
-npx vitest run   # Run all tests (32 tests across 8 files)
+npx vitest run   # Run all tests (109+ tests across 9 files)
 ```
 
 ## Architecture
@@ -46,10 +46,11 @@ src/
   types.ts               Shared interfaces (BountyIssue, WatchlistConfig, SeenIssue, etc.)
   config.ts              YAML config loader, data dir management (~/.bounty-hunter/)
   seen.ts                SeenStore — JSON-backed deduplication (seen.json)
-  github.ts              GitHub issue fetcher (wraps gh CLI via execFileSync)
+  github.ts              GitHub issue fetcher + comment fetcher (wraps gh CLI via execFileSync)
   algora.ts              Algora tRPC client (public API, amounts in cents)
-  telegram.ts            Telegram Bot API client (send messages, get updates)
-  monitor.ts             Background polling loop + pre-filter logic
+  telegram.ts            Telegram Bot API client (send messages, get updates, vet-enriched notifications)
+  vet.ts                 Issue vetting — rule-based checks (access, competition, bounty, platform)
+  monitor.ts             Background polling loop + pre-filter + vetting integration
   index.ts               CLI entry point (scan, notify, post-comment, seen, config)
   install-launchd.ts     macOS launchd plist generator and installer
 
@@ -87,23 +88,28 @@ templates/
 ## Core Types (src/types.ts)
 
 - `BountyIssue` — normalized issue from GitHub or Algora (source, repo, number, title, url, bounty_amount, labels, body)
-- `WatchlistConfig` — top-level config shape (polling_interval, telegram, sources)
+- `WatchlistConfig` — top-level config shape (polling_interval, telegram, sources, filters, vetting)
 - `RepoSource` — individual GitHub repo config (name, labels, proposal_template, pre_filter)
 - `AlgoraSource` — Algora config (enabled, min_bounty, languages, keywords_exclude)
 - `SeenIssue` — deduplication record (id, repo, number, title, seen_at, skipped)
 - `TelegramConfig` — bot_token + chat_id
+- `VettingConfig` — vetting rules (enabled, on_fail, max_proposals, access_keywords, platform_keywords, etc.)
+- `IssueComment` — GitHub comment (author, authorAssociation, body, createdAt, url)
+- `VetSignal` — individual vetting check result (name, passed, detail)
+- `VetResult` — aggregate vetting result (passed, signals, proposal_count, summary)
 
 ## Data Flow
 
 1. `config.ts` loads `~/.bounty-hunter/watchlist.yml` → `WatchlistConfig`
-2. `monitor.ts` iterates repos: `fetchRepoIssues()` → `applyPreFilter()` → `seen.hasSeen()` → `seen.markSeenFromBounty()`
-3. `monitor.ts` polls Algora: `fetchAlgoraBounties(buildAlgoraFilters())` → `seen.hasSeen()` → `seen.markSeenFromBounty()`
-4. New issues → `formatBountyNotification()` → `sendTelegramMessage()`
+2. `monitor.ts` iterates repos: `fetchRepoIssues()` → `applyPreFilter()` → `applyFreshnessFilter()` → `seen.markSeenFromBounty()`
+3. `monitor.ts` vets survivors: `fetchIssueComments()` → `vetIssue()` → `shouldNotify()`
+4. `monitor.ts` polls Algora: `fetchAlgoraBounties(buildAlgoraFilters())` → freshness → vet (body-only, no comments)
+5. New issues → `formatBountyNotification(issue, vetResult?)` → `sendTelegramMessage()`
 
 ## Testing
 
 - Tests live alongside source as `*.test.ts`
-- 32 tests across 8 files
+- 109+ tests across 9 files
 - Integration test (`integration.test.ts`) hits real GitHub API via `gh` — requires `gh auth status`
 - Integration test overrides `HOME` to isolate config; preserves `GH_CONFIG_DIR` for auth
 - Run: `npx vitest run` (all tests) or `npx vitest run src/github.test.ts` (single file)

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -141,6 +141,86 @@ sources:
   });
 });
 
+describe("vetting config defaults", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("fills in default vetting config when vetting section is omitted", () => {
+    const yml = `
+polling_interval: 5
+telegram:
+  bot_token: "test-token"
+  chat_id: "12345"
+sources:
+  repos: []
+  algora:
+    enabled: false
+    min_bounty: 0
+    languages: []
+    keywords_exclude: []
+`;
+    writeFileSync(join(TEST_DIR, "watchlist.yml"), yml);
+    const config = loadConfig(join(TEST_DIR, "watchlist.yml"));
+    expect(config.vetting).toBeDefined();
+    expect(config.vetting.enabled).toBe(true);
+    expect(config.vetting.on_fail).toBe("skip");
+    expect(config.vetting.max_proposals).toBe(3);
+    expect(config.vetting.access_keywords).toContain("staging server");
+    expect(config.vetting.proposal_patterns).toContain("## Proposal");
+  });
+
+  it("allows partial override of vetting config", () => {
+    const yml = `
+polling_interval: 5
+telegram:
+  bot_token: "test-token"
+  chat_id: "12345"
+vetting:
+  on_fail: "warn"
+  max_proposals: 5
+sources:
+  repos: []
+  algora:
+    enabled: false
+    min_bounty: 0
+    languages: []
+    keywords_exclude: []
+`;
+    writeFileSync(join(TEST_DIR, "watchlist.yml"), yml);
+    const config = loadConfig(join(TEST_DIR, "watchlist.yml"));
+    expect(config.vetting.on_fail).toBe("warn");
+    expect(config.vetting.max_proposals).toBe(5);
+    // Defaults still apply for unspecified fields
+    expect(config.vetting.enabled).toBe(true);
+    expect(config.vetting.access_keywords).toContain("staging server");
+  });
+
+  it("validates on_fail enum values", () => {
+    const yml = `
+polling_interval: 5
+telegram:
+  bot_token: "test-token"
+  chat_id: "12345"
+vetting:
+  on_fail: "invalid_value"
+sources:
+  repos: []
+  algora:
+    enabled: false
+    min_bounty: 0
+    languages: []
+    keywords_exclude: []
+`;
+    writeFileSync(join(TEST_DIR, "watchlist.yml"), yml);
+    expect(() => loadConfig(join(TEST_DIR, "watchlist.yml"))).toThrow();
+  });
+});
+
 describe("ensureDataDir", () => {
   it("creates the data directory structure", () => {
     ensureDataDir(TEST_DIR);

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseIssueUrl, buildSearchArgs } from "./github.js";
+import { parseIssueUrl, buildSearchArgs, buildIssueViewArgs } from "./github.js";
 
 describe("parseIssueUrl", () => {
   it("parses a standard GitHub issue URL", () => {
@@ -41,5 +41,28 @@ describe("buildSearchArgs", () => {
     // Each label should be preceded by --label
     const labelFlags = args.reduce((count, arg) => arg === "--label" ? count + 1 : count, 0);
     expect(labelFlags).toBe(3);
+  });
+});
+
+describe("buildIssueViewArgs", () => {
+  it("builds gh issue view args for fetching comments", () => {
+    const args = buildIssueViewArgs("Expensify/App", 81500);
+    expect(args).toContain("issue");
+    expect(args).toContain("view");
+    expect(args).toContain("81500");
+    expect(args).toContain("Expensify/App");
+    expect(args).toContain("comments");
+  });
+
+  it("uses --repo flag for the repo", () => {
+    const args = buildIssueViewArgs("Expensify/App", 100);
+    const repoIdx = args.indexOf("--repo");
+    expect(repoIdx).toBeGreaterThan(-1);
+    expect(args[repoIdx + 1]).toBe("Expensify/App");
+  });
+
+  it("passes issue number as string", () => {
+    const args = buildIssueViewArgs("foo/bar", 42);
+    expect(args).toContain("42");
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import type { BountyIssue, IssueComment } from "./types.js";
+import type { BountyIssue, GitHubAuthorAssociation, IssueComment } from "./types.js";
 
 interface ParsedIssueUrl {
   owner: string;
@@ -81,7 +81,7 @@ export function fetchIssueComments(
   const raw = execFileSync("gh", args, { encoding: "utf-8", timeout: 30000 });
   const data = JSON.parse(raw) as {
     comments: Array<{
-      author: { login: string };
+      author: { login: string } | null;
       authorAssociation: string;
       body: string;
       createdAt: string;
@@ -89,8 +89,8 @@ export function fetchIssueComments(
     }>;
   };
   return data.comments.map((c) => ({
-    author: c.author.login,
-    authorAssociation: c.authorAssociation,
+    author: c.author?.login ?? "ghost",
+    authorAssociation: (c.authorAssociation ?? "NONE") as GitHubAuthorAssociation,
     body: c.body,
     createdAt: c.createdAt,
     url: c.url,

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import type { BountyIssue } from "./types.js";
+import type { BountyIssue, IssueComment } from "./types.js";
 
 interface ParsedIssueUrl {
   owner: string;
@@ -58,6 +58,42 @@ export function fetchRepoIssues(repo: string, labels: string[]): BountyIssue[] {
     created_at: issue.createdAt,
     bounty_amount: extractBountyAmount(issue.title + " " + issue.body),
     bounty_formatted: extractBountyFormatted(issue.title),
+  }));
+}
+
+export function buildIssueViewArgs(repo: string, number: number): string[] {
+  return [
+    "issue",
+    "view",
+    String(number),
+    "--repo",
+    repo,
+    "--json",
+    "comments",
+  ];
+}
+
+export function fetchIssueComments(
+  repo: string,
+  number: number
+): IssueComment[] {
+  const args = buildIssueViewArgs(repo, number);
+  const raw = execFileSync("gh", args, { encoding: "utf-8", timeout: 30000 });
+  const data = JSON.parse(raw) as {
+    comments: Array<{
+      author: { login: string };
+      authorAssociation: string;
+      body: string;
+      createdAt: string;
+      url: string;
+    }>;
+  };
+  return data.comments.map((c) => ({
+    author: c.author.login,
+    authorAssociation: c.authorAssociation,
+    body: c.body,
+    createdAt: c.createdAt,
+    url: c.url,
   }));
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,8 +36,11 @@ async function main() {
             try {
               const comments = fetchIssueComments(issue.repo, issue.number);
               vetResult = vetIssue(issue, comments, config.vetting);
-            } catch {
-              // Vetting failure doesn't block scan output
+            } catch (err) {
+              console.error(
+                `  Vetting error for ${issue.repo}#${issue.number}:`,
+                err instanceof Error ? err.message : err
+              );
             }
           }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 
 import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
-import { fetchRepoIssues } from "./github.js";
+import { fetchRepoIssues, fetchIssueComments } from "./github.js";
 import { fetchAlgoraBounties, buildAlgoraFilters } from "./algora.js";
 import { SeenStore } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
 import { applyPreFilter, applyFreshnessFilter } from "./monitor.js";
+import { vetIssue } from "./vet.js";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
+import type { VetResult } from "./types.js";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -20,14 +22,30 @@ async function main() {
       const dataDir = getDataDir();
       ensureDataDir(dataDir);
       const seen = new SeenStore(join(dataDir, "seen.json"));
-      const allIssues = [];
+      const vettingEnabled = config.vetting.enabled;
+      const allIssues: Array<Record<string, unknown>> = [];
 
       for (const repo of config.sources.repos) {
         const issues = fetchRepoIssues(repo.name, repo.labels);
         for (const issue of issues) {
           if (!applyPreFilter(issue, repo.pre_filter)) continue;
           if (!applyFreshnessFilter(issue, config.filters)) continue;
-          allIssues.push({ ...issue, is_new: !seen.hasSeen(issue.repo, issue.number) });
+
+          let vetResult: VetResult | undefined;
+          if (vettingEnabled) {
+            try {
+              const comments = fetchIssueComments(issue.repo, issue.number);
+              vetResult = vetIssue(issue, comments, config.vetting);
+            } catch {
+              // Vetting failure doesn't block scan output
+            }
+          }
+
+          allIssues.push({
+            ...issue,
+            is_new: !seen.hasSeen(issue.repo, issue.number),
+            ...(vetResult ? { vetResult } : {}),
+          });
         }
       }
 
@@ -35,7 +53,17 @@ async function main() {
         const bounties = await fetchAlgoraBounties(buildAlgoraFilters(config.sources.algora));
         for (const issue of bounties) {
           if (!applyFreshnessFilter(issue, config.filters)) continue;
-          allIssues.push({ ...issue, is_new: !seen.hasSeen(issue.repo, issue.number) });
+
+          let vetResult: VetResult | undefined;
+          if (vettingEnabled) {
+            vetResult = vetIssue(issue, [], config.vetting);
+          }
+
+          allIssues.push({
+            ...issue,
+            is_new: !seen.hasSeen(issue.repo, issue.number),
+            ...(vetResult ? { vetResult } : {}),
+          });
         }
       }
 
@@ -44,8 +72,13 @@ async function main() {
       } else {
         for (const issue of allIssues) {
           const marker = issue.is_new ? "NEW" : "   ";
-          const bounty = issue.bounty_formatted ?? "    ";
-          console.log(`[${marker}] ${bounty.padEnd(8)} ${issue.repo}#${issue.number} — ${issue.title}`);
+          const bounty = (issue.bounty_formatted as string) ?? "    ";
+          const vet = issue.vetResult
+            ? (issue.vetResult as VetResult).passed
+              ? " \u2705"
+              : " \u26a0\ufe0f"
+            : "";
+          console.log(`[${marker}] ${bounty.padEnd(8)} ${issue.repo}#${issue.number} — ${issue.title}${vet}`);
         }
       }
       break;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ import { applyPreFilter, applyFreshnessFilter } from "./monitor.js";
 import { vetIssue } from "./vet.js";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
-import type { VetResult } from "./types.js";
+import type { BountyIssue, VetResult } from "./types.js";
+
+interface ScanResult extends BountyIssue {
+  is_new: boolean;
+  vetResult?: VetResult;
+}
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -23,10 +28,16 @@ async function main() {
       ensureDataDir(dataDir);
       const seen = new SeenStore(join(dataDir, "seen.json"));
       const vettingEnabled = config.vetting.enabled;
-      const allIssues: Array<Record<string, unknown>> = [];
+      const allIssues: ScanResult[] = [];
 
       for (const repo of config.sources.repos) {
-        const issues = fetchRepoIssues(repo.name, repo.labels);
+        let issues: BountyIssue[];
+        try {
+          issues = fetchRepoIssues(repo.name, repo.labels);
+        } catch (err) {
+          console.error(`Error fetching ${repo.name}:`, err instanceof Error ? err.message : err);
+          continue;
+        }
         for (const issue of issues) {
           if (!applyPreFilter(issue, repo.pre_filter)) continue;
           if (!applyFreshnessFilter(issue, config.filters)) continue;
@@ -75,9 +86,9 @@ async function main() {
       } else {
         for (const issue of allIssues) {
           const marker = issue.is_new ? "NEW" : "   ";
-          const bounty = (issue.bounty_formatted as string) ?? "    ";
+          const bounty = issue.bounty_formatted ?? "    ";
           const vet = issue.vetResult
-            ? (issue.vetResult as VetResult).passed
+            ? issue.vetResult.passed
               ? " \u2705"
               : " \u26a0\ufe0f"
             : "";

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -153,8 +153,6 @@ describe("shouldNotify", () => {
     signals: [],
     proposal_count: 0,
     has_approved_proposal: false,
-    access_keywords_found: [],
-    platform_keywords_found: [],
     summary: passed ? "Vetted: OK" : "Failed: access_requirements",
   });
 

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { applyPreFilter, applyFreshnessFilter } from "./monitor.js";
-import type { BountyIssue, Filters } from "./types.js";
+import { applyPreFilter, applyFreshnessFilter, shouldNotify } from "./monitor.js";
+import type { BountyIssue, Filters, VetResult } from "./types.js";
 
 const makeIssue = (overrides: Partial<BountyIssue> = {}): BountyIssue => ({
   source: "github",
@@ -144,5 +144,45 @@ describe("applyFreshnessFilter", () => {
       const issue = makeIssue({ comment_count: 100 });
       expect(applyFreshnessFilter(issue, { ...defaultFilters, max_comment_count: 0 })).toBe(true);
     });
+  });
+});
+
+describe("shouldNotify", () => {
+  const makeVetResult = (passed: boolean): VetResult => ({
+    passed,
+    signals: [],
+    proposal_count: 0,
+    has_approved_proposal: false,
+    access_keywords_found: [],
+    platform_keywords_found: [],
+    summary: passed ? "Vetted: OK" : "Failed: access_requirements",
+  });
+
+  it("always notifies when no vet result is provided", () => {
+    expect(shouldNotify(undefined, "skip")).toBe(true);
+    expect(shouldNotify(undefined, "warn")).toBe(true);
+    expect(shouldNotify(undefined, "notify_all")).toBe(true);
+  });
+
+  it("always notifies when vetting passed", () => {
+    const passed = makeVetResult(true);
+    expect(shouldNotify(passed, "skip")).toBe(true);
+    expect(shouldNotify(passed, "warn")).toBe(true);
+    expect(shouldNotify(passed, "notify_all")).toBe(true);
+  });
+
+  it("skips notification on failed vetting with on_fail=skip", () => {
+    const failed = makeVetResult(false);
+    expect(shouldNotify(failed, "skip")).toBe(false);
+  });
+
+  it("notifies with warning on failed vetting with on_fail=warn", () => {
+    const failed = makeVetResult(false);
+    expect(shouldNotify(failed, "warn")).toBe(true);
+  });
+
+  it("notifies on failed vetting with on_fail=notify_all", () => {
+    const failed = makeVetResult(false);
+    expect(shouldNotify(failed, "notify_all")).toBe(true);
   });
 });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,11 +1,19 @@
 import { fileURLToPath } from "node:url";
 import { resolve, join } from "node:path";
 import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
-import { fetchRepoIssues } from "./github.js";
+import { fetchRepoIssues, fetchIssueComments } from "./github.js";
 import { fetchAlgoraBounties, buildAlgoraFilters } from "./algora.js";
 import { SeenStore } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
-import type { BountyIssue, Filters, RepoSource } from "./types.js";
+import { vetIssue } from "./vet.js";
+import type {
+  BountyIssue,
+  Filters,
+  IssueComment,
+  RepoSource,
+  VetResult,
+  VettingConfig,
+} from "./types.js";
 
 export function applyPreFilter(issue: BountyIssue, filter: RepoSource["pre_filter"]): boolean {
   if (!filter?.keywords_exclude?.length) return true;
@@ -40,13 +48,35 @@ export function applyFreshnessFilter(issue: BountyIssue, filters: Filters): bool
   return true;
 }
 
+/**
+ * Determines whether to notify for an issue based on vetting result and on_fail mode.
+ * Returns { notify, vetResult } — notify=true means send a Telegram message.
+ */
+export function shouldNotify(
+  vetResult: VetResult | undefined,
+  onFail: VettingConfig["on_fail"]
+): boolean {
+  if (!vetResult) return true; // No vetting = always notify
+  if (vetResult.passed) return true;
+
+  switch (onFail) {
+    case "skip":
+      return false;
+    case "warn":
+      return true;
+    case "notify_all":
+      return true;
+  }
+}
+
 export async function runMonitor(): Promise<void> {
   const config = loadConfig();
   const dataDir = getDataDir();
   ensureDataDir(dataDir);
   const seen = new SeenStore(join(dataDir, "seen.json"));
+  const vettingEnabled = config.vetting.enabled;
 
-  const allNew: BountyIssue[] = [];
+  const allNew: Array<{ issue: BountyIssue; vetResult?: VetResult }> = [];
 
   // Poll GitHub repos
   for (const repo of config.sources.repos) {
@@ -56,8 +86,26 @@ export async function runMonitor(): Promise<void> {
         if (seen.hasSeen(issue.repo, issue.number)) continue;
         if (!applyPreFilter(issue, repo.pre_filter)) continue;
         if (!applyFreshnessFilter(issue, config.filters)) continue;
-        allNew.push(issue);
+
+        // Mark seen regardless of vetting outcome to prevent re-checking
         seen.markSeenFromBounty(issue);
+
+        // Vet the issue if enabled
+        let vetResult: VetResult | undefined;
+        if (vettingEnabled) {
+          try {
+            const comments = fetchIssueComments(issue.repo, issue.number);
+            vetResult = vetIssue(issue, comments, config.vetting);
+          } catch (err) {
+            // Broken vetting should never silently drop bounties — notify anyway
+            console.error(
+              `  Vetting error for ${issue.repo}#${issue.number}:`,
+              err
+            );
+          }
+        }
+
+        allNew.push({ issue, vetResult });
       }
     } catch (err) {
       console.error(`Error polling ${repo.name}:`, err);
@@ -71,8 +119,16 @@ export async function runMonitor(): Promise<void> {
       for (const issue of bounties) {
         if (seen.hasSeen(issue.repo, issue.number)) continue;
         if (!applyFreshnessFilter(issue, config.filters)) continue;
-        allNew.push(issue);
+
         seen.markSeenFromBounty(issue);
+
+        // Vet Algora issues with empty comments (body-based checks still apply)
+        let vetResult: VetResult | undefined;
+        if (vettingEnabled) {
+          vetResult = vetIssue(issue, [], config.vetting);
+        }
+
+        allNew.push({ issue, vetResult });
       }
     } catch (err) {
       console.error("Error polling Algora:", err);
@@ -87,9 +143,14 @@ export async function runMonitor(): Promise<void> {
 
   console.log(`[${new Date().toISOString()}] Found ${allNew.length} new bounties!`);
 
-  for (const issue of allNew) {
+  for (const { issue, vetResult } of allNew) {
+    if (!shouldNotify(vetResult, config.vetting.on_fail)) {
+      console.log(`  Skipped (vetting): ${issue.repo}#${issue.number} — ${vetResult?.summary}`);
+      continue;
+    }
+
     try {
-      const message = formatBountyNotification(issue);
+      const message = formatBountyNotification(issue, vetResult);
       await sendTelegramMessage(config.telegram, message);
       console.log(`  Notified: ${issue.repo}#${issue.number}`);
     } catch (err) {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -9,7 +9,6 @@ import { vetIssue } from "./vet.js";
 import type {
   BountyIssue,
   Filters,
-  IssueComment,
   RepoSource,
   VetResult,
   VettingConfig,
@@ -50,7 +49,7 @@ export function applyFreshnessFilter(issue: BountyIssue, filters: Filters): bool
 
 /**
  * Determines whether to notify for an issue based on vetting result and on_fail mode.
- * Returns { notify, vetResult } — notify=true means send a Telegram message.
+ * Returns true if a Telegram message should be sent.
  */
 export function shouldNotify(
   vetResult: VetResult | undefined,
@@ -162,5 +161,8 @@ export async function runMonitor(): Promise<void> {
 // Entry point when run directly
 const isMain = fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (isMain) {
-  runMonitor().catch(console.error);
+  runMonitor().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -65,6 +65,10 @@ export function shouldNotify(
       return true;
     case "notify_all":
       return true;
+    default: {
+      const _exhaustive: never = onFail;
+      return _exhaustive;
+    }
   }
 }
 

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -74,6 +74,7 @@ describe("formatBountyNotification", () => {
     const msg = formatBountyNotification(makeIssue(), vetResult);
     expect(msg).toContain("\u26a0\ufe0f"); // ⚠️
     expect(msg).toContain("Failed: access_requirements, competition");
+    expect(msg).not.toContain("Vetted: Failed:"); // no redundant prefix
     expect(msg).toContain("Proposals: 4");
   });
 

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -1,33 +1,37 @@
 import { describe, it, expect } from "vitest";
 import { formatBountyNotification } from "./telegram.js";
-import type { BountyIssue } from "./types.js";
+import type { BountyIssue, VetResult } from "./types.js";
+
+const makeIssue = (overrides: Partial<BountyIssue> = {}): BountyIssue => ({
+  source: "github",
+  repo: "Expensify/App",
+  number: 81500,
+  title: "Fix modal doesn't close on escape key",
+  url: "https://github.com/Expensify/App/issues/81500",
+  bounty_amount: 250,
+  bounty_formatted: "$250",
+  labels: ["Help Wanted", "Bug"],
+  assignees: [],
+  body: "Some description",
+  comment_count: 0,
+  created_at: "2026-02-05T12:00:00Z",
+  ...overrides,
+});
 
 describe("formatBountyNotification", () => {
-  it("formats a GitHub bounty issue", () => {
-    const issue: BountyIssue = {
-      source: "github",
-      repo: "Expensify/App",
-      number: 81500,
-      title: "Fix modal doesn't close on escape key",
-      url: "https://github.com/Expensify/App/issues/81500",
-      bounty_amount: 250,
-      bounty_formatted: "$250",
-      labels: ["Help Wanted", "Bug"],
-      assignees: [],
-      body: "Some description",
-      comment_count: 0,
-      created_at: "2026-02-05T12:00:00Z",
-    };
-    const msg = formatBountyNotification(issue);
+  it("formats a GitHub bounty issue (no vet result)", () => {
+    const msg = formatBountyNotification(makeIssue());
     expect(msg).toContain("Expensify/App");
     expect(msg).toContain("#81500");
     expect(msg).toContain("$250");
-    expect(msg).toContain("0");
+    expect(msg).toContain("Proposals: 0");
     expect(msg).toContain("https://github.com/Expensify/App/issues/81500");
+    // Default emoji when no vet result
+    expect(msg).toContain("\ud83c\udfaf");
   });
 
   it("formats an Algora bounty issue", () => {
-    const issue: BountyIssue = {
+    const issue = makeIssue({
       source: "algora",
       repo: "coolify/coolify",
       number: 8154,
@@ -36,14 +40,60 @@ describe("formatBountyNotification", () => {
       bounty_amount: 6900,
       bounty_formatted: "$6,900",
       labels: [],
-      assignees: [],
       body: "",
       comment_count: 0,
-      created_at: "2026-02-05T12:00:00Z",
       tech: ["php", "vue"],
-    };
+    });
     const msg = formatBountyNotification(issue);
     expect(msg).toContain("$6,900");
     expect(msg).toContain("Algora");
+  });
+
+  it("shows checkmark and OK for passed vetting", () => {
+    const vetResult: VetResult = {
+      passed: true,
+      signals: [],
+      proposal_count: 1,
+      has_approved_proposal: false,
+      access_keywords_found: [],
+      platform_keywords_found: [],
+      summary: "Vetted: OK",
+    };
+    const msg = formatBountyNotification(makeIssue(), vetResult);
+    expect(msg).toContain("\u2705"); // ✅
+    expect(msg).toContain("Vetted: OK");
+    expect(msg).toContain("Proposals: 1");
+  });
+
+  it("shows warning and summary for failed vetting", () => {
+    const vetResult: VetResult = {
+      passed: false,
+      signals: [],
+      proposal_count: 4,
+      has_approved_proposal: false,
+      access_keywords_found: ["staging server"],
+      platform_keywords_found: [],
+      summary: "Failed: access_requirements, competition",
+    };
+    const msg = formatBountyNotification(makeIssue(), vetResult);
+    expect(msg).toContain("\u26a0\ufe0f"); // ⚠️
+    expect(msg).toContain("Failed: access_requirements, competition");
+    expect(msg).toContain("Proposals: 4");
+  });
+
+  it("uses verified proposal_count instead of raw comment_count", () => {
+    const issue = makeIssue({ comment_count: 15 });
+    const vetResult: VetResult = {
+      passed: true,
+      signals: [],
+      proposal_count: 2,
+      has_approved_proposal: false,
+      access_keywords_found: [],
+      platform_keywords_found: [],
+      summary: "Vetted: OK",
+    };
+    const msg = formatBountyNotification(issue, vetResult);
+    expect(msg).toContain("Proposals: 2");
+    expect(msg).not.toContain("Proposals: 15");
   });
 });

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -55,8 +55,6 @@ describe("formatBountyNotification", () => {
       signals: [],
       proposal_count: 1,
       has_approved_proposal: false,
-      access_keywords_found: [],
-      platform_keywords_found: [],
       summary: "Vetted: OK",
     };
     const msg = formatBountyNotification(makeIssue(), vetResult);
@@ -71,8 +69,6 @@ describe("formatBountyNotification", () => {
       signals: [],
       proposal_count: 4,
       has_approved_proposal: false,
-      access_keywords_found: ["staging server"],
-      platform_keywords_found: [],
       summary: "Failed: access_requirements, competition",
     };
     const msg = formatBountyNotification(makeIssue(), vetResult);
@@ -88,8 +84,6 @@ describe("formatBountyNotification", () => {
       signals: [],
       proposal_count: 2,
       has_approved_proposal: false,
-      access_keywords_found: [],
-      platform_keywords_found: [],
       summary: "Vetted: OK",
     };
     const msg = formatBountyNotification(issue, vetResult);

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -29,7 +29,7 @@ export function formatBountyNotification(
       vetLine = `\nVetted: OK`;
     } else {
       prefix = "\u26a0\ufe0f"; // ⚠️
-      vetLine = `\nVetted: ${vetResult.summary}`;
+      vetLine = `\n${vetResult.summary}`;
     }
   } else {
     prefix = "\ud83c\udfaf"; // 🎯

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -1,18 +1,45 @@
-import type { BountyIssue, TelegramConfig } from "./types.js";
+import type { BountyIssue, TelegramConfig, VetResult } from "./types.js";
 
 const API_BASE = "https://api.telegram.org/bot";
 
-export function formatBountyNotification(issue: BountyIssue): string {
+export function formatBountyNotification(
+  issue: BountyIssue,
+  vetResult?: VetResult
+): string {
   const source = issue.source === "algora" ? " (Algora)" : "";
   const bounty = issue.bounty_formatted ? ` — ${issue.bounty_formatted}` : "";
-  const labels = issue.labels.length ? `\nLabels: ${issue.labels.join(", ")}` : "";
+  const labels = issue.labels.length
+    ? `\nLabels: ${issue.labels.join(", ")}`
+    : "";
   const tech = issue.tech?.length ? `\nTech: ${issue.tech.join(", ")}` : "";
-  const proposals = `\nProposals: ${issue.comment_count}`;
+
+  // Use verified proposal count when available, fall back to raw comment count
+  const proposalCount = vetResult
+    ? vetResult.proposal_count
+    : issue.comment_count;
+  const proposals = `\nProposals: ${proposalCount}`;
+
+  // Determine emoji prefix and vetting status line
+  let prefix: string;
+  let vetLine: string;
+
+  if (vetResult) {
+    if (vetResult.passed) {
+      prefix = "\u2705"; // ✅
+      vetLine = `\nVetted: OK`;
+    } else {
+      prefix = "\u26a0\ufe0f"; // ⚠️
+      vetLine = `\nVetted: ${vetResult.summary}`;
+    }
+  } else {
+    prefix = "\ud83c\udfaf"; // 🎯
+    vetLine = "";
+  }
 
   return [
-    `🎯 ${issue.repo} #${issue.number}${bounty}${source}`,
+    `${prefix} ${issue.repo} #${issue.number}${bounty}${source}`,
     `"${issue.title}"`,
-    `${labels}${tech}${proposals}`,
+    `${labels}${tech}${proposals}${vetLine}`,
     `\n${issue.url}`,
     `\nReply "skip" to dismiss`,
   ].join("\n");

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export const VettingConfigSchema = z.object({
   on_fail: z
     .enum(["skip", "warn", "notify_all"])
     .default(VETTING_DEFAULTS.on_fail),
-  max_proposals: z.number().default(VETTING_DEFAULTS.max_proposals),
+  max_proposals: z.number().int().min(0).default(VETTING_DEFAULTS.max_proposals),
   access_keywords: z
     .array(z.string())
     .default([...VETTING_DEFAULTS.access_keywords]),
@@ -147,18 +147,35 @@ export interface BountyIssue {
   tech?: string[];
 }
 
+export type GitHubAuthorAssociation =
+  | "OWNER"
+  | "MEMBER"
+  | "COLLABORATOR"
+  | "CONTRIBUTOR"
+  | "FIRST_TIMER"
+  | "FIRST_TIME_CONTRIBUTOR"
+  | "MANNEQUIN"
+  | "NONE";
+
 export interface IssueComment {
   author: string;
-  authorAssociation: string;
+  authorAssociation: GitHubAuthorAssociation;
   body: string;
   createdAt: string;
   url: string;
 }
 
+export type VetSignalName =
+  | "access_requirements"
+  | "competition"
+  | "bounty_confirmation"
+  | "platform_requirements";
+
 export interface VetSignal {
-  name: string;
+  name: VetSignalName;
   passed: boolean;
   detail: string;
+  found?: string[];
 }
 
 export interface VetResult {
@@ -166,7 +183,5 @@ export interface VetResult {
   signals: VetSignal[];
   proposal_count: number;
   has_approved_proposal: boolean;
-  access_keywords_found: string[];
-  platform_keywords_found: string[];
   summary: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,52 @@ const FiltersObjectSchema = z.object({
 
 export const FiltersSchema = FiltersObjectSchema;
 
+const VETTING_DEFAULTS = {
+  enabled: true,
+  on_fail: "skip" as const,
+  max_proposals: 3,
+  access_keywords: [
+    "staging server",
+    "staging environment",
+    "internal tool",
+    "internal slack",
+    "internal stack overflow",
+    "stackoverflow.com/c/",
+    "vpn",
+    "internal wiki",
+    "century",
+    "admin console",
+    "internal dashboard",
+    "dev environment",
+    "test account provided",
+  ],
+  platform_keywords: [] as string[],
+  proposal_patterns: ["## Proposal", "### Please re-state the problem"],
+  require_bounty_label: false,
+  bounty_labels: ["Help Wanted"],
+} as const;
+
+export const VettingConfigSchema = z.object({
+  enabled: z.boolean().default(VETTING_DEFAULTS.enabled),
+  on_fail: z
+    .enum(["skip", "warn", "notify_all"])
+    .default(VETTING_DEFAULTS.on_fail),
+  max_proposals: z.number().default(VETTING_DEFAULTS.max_proposals),
+  access_keywords: z
+    .array(z.string())
+    .default([...VETTING_DEFAULTS.access_keywords]),
+  platform_keywords: z.array(z.string()).default([]),
+  proposal_patterns: z
+    .array(z.string())
+    .default([...VETTING_DEFAULTS.proposal_patterns]),
+  require_bounty_label: z
+    .boolean()
+    .default(VETTING_DEFAULTS.require_bounty_label),
+  bounty_labels: z
+    .array(z.string())
+    .default([...VETTING_DEFAULTS.bounty_labels]),
+});
+
 export const WatchlistConfigSchema = z.object({
   polling_interval: z.number(),
   telegram: TelegramConfigSchema,
@@ -54,6 +100,16 @@ export const WatchlistConfigSchema = z.object({
     ...FILTER_DEFAULTS,
     claimed_labels: [...FILTER_DEFAULTS.claimed_labels],
   }),
+  vetting: VettingConfigSchema.optional().default({
+    enabled: VETTING_DEFAULTS.enabled,
+    on_fail: VETTING_DEFAULTS.on_fail,
+    max_proposals: VETTING_DEFAULTS.max_proposals,
+    access_keywords: [...VETTING_DEFAULTS.access_keywords],
+    platform_keywords: [...VETTING_DEFAULTS.platform_keywords],
+    proposal_patterns: [...VETTING_DEFAULTS.proposal_patterns],
+    require_bounty_label: VETTING_DEFAULTS.require_bounty_label,
+    bounty_labels: [...VETTING_DEFAULTS.bounty_labels],
+  }),
 });
 
 // Derive types from schemas
@@ -61,6 +117,7 @@ export type RepoSource = z.infer<typeof RepoSourceSchema>;
 export type AlgoraSource = z.infer<typeof AlgoraSourceSchema>;
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type Filters = z.infer<typeof FiltersSchema>;
+export type VettingConfig = z.infer<typeof VettingConfigSchema>;
 export type WatchlistConfig = z.infer<typeof WatchlistConfigSchema>;
 
 // --- Non-config types (plain interfaces) ---
@@ -88,4 +145,28 @@ export interface BountyIssue {
   comment_count: number;
   created_at: string;
   tech?: string[];
+}
+
+export interface IssueComment {
+  author: string;
+  authorAssociation: string;
+  body: string;
+  createdAt: string;
+  url: string;
+}
+
+export interface VetSignal {
+  name: string;
+  passed: boolean;
+  detail: string;
+}
+
+export interface VetResult {
+  passed: boolean;
+  signals: VetSignal[];
+  proposal_count: number;
+  has_approved_proposal: boolean;
+  access_keywords_found: string[];
+  platform_keywords_found: string[];
+  summary: string;
 }

--- a/src/vet.test.ts
+++ b/src/vet.test.ts
@@ -1,0 +1,527 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkAccessRequirements,
+  checkCompetition,
+  checkBountyConfirmation,
+  checkPlatformRequirements,
+  countProposals,
+  vetIssue,
+} from "./vet.js";
+import type { BountyIssue, IssueComment, VettingConfig } from "./types.js";
+
+// --- Helpers ---
+
+const makeIssue = (overrides: Partial<BountyIssue> = {}): BountyIssue => ({
+  source: "github",
+  repo: "Expensify/App",
+  number: 100,
+  title: "Fix button",
+  url: "https://github.com/Expensify/App/issues/100",
+  labels: ["Help Wanted"],
+  assignees: [],
+  body: "Description of the bug",
+  comment_count: 0,
+  created_at: "2026-02-05T00:00:00Z",
+  ...overrides,
+});
+
+const makeComment = (
+  overrides: Partial<IssueComment> = {}
+): IssueComment => ({
+  author: "user123",
+  authorAssociation: "NONE",
+  body: "Some comment",
+  createdAt: "2026-02-06T00:00:00Z",
+  url: "https://github.com/Expensify/App/issues/100#issuecomment-1",
+  ...overrides,
+});
+
+const defaultAccessKeywords = [
+  "staging server",
+  "staging environment",
+  "internal tool",
+  "internal slack",
+  "internal stack overflow",
+  "stackoverflow.com/c/",
+  "vpn",
+  "internal wiki",
+  "century",
+  "admin console",
+  "internal dashboard",
+  "dev environment",
+  "test account provided",
+];
+
+const defaultProposalPatterns = [
+  "## Proposal",
+  "### Please re-state the problem",
+];
+
+const defaultVettingConfig: VettingConfig = {
+  enabled: true,
+  on_fail: "skip",
+  max_proposals: 3,
+  access_keywords: defaultAccessKeywords,
+  platform_keywords: [],
+  proposal_patterns: defaultProposalPatterns,
+  require_bounty_label: false,
+  bounty_labels: ["Help Wanted"],
+};
+
+// --- Access Requirements ---
+
+describe("checkAccessRequirements", () => {
+  it("passes when no access keywords found in body or comments", () => {
+    const issue = makeIssue({ body: "Simple CSS bug" });
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when keyword found in issue body", () => {
+    const issue = makeIssue({
+      body: "To reproduce, log into the staging server and navigate to...",
+    });
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("staging server");
+  });
+
+  it("fails when keyword found in comments", () => {
+    const issue = makeIssue();
+    const comments = [
+      makeComment({
+        body: "You need access to the internal tool to test this",
+      }),
+    ];
+    const result = checkAccessRequirements(issue, comments, defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("internal tool");
+  });
+
+  it("is case-insensitive", () => {
+    const issue = makeIssue({ body: "Use the STAGING SERVER to test" });
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+  });
+
+  it("detects internal URL patterns (*.internal.*)", () => {
+    const issue = makeIssue({
+      body: "Check results at dashboard.internal.company.com",
+    });
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("internal URL pattern");
+  });
+
+  it("detects internal URL patterns (*.corp.*)", () => {
+    const issue = makeIssue({
+      body: "Visit tools.corp.expensify.com for details",
+    });
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("internal URL pattern");
+  });
+
+  it("detects stackoverflow.com/c/ (private Teams SO)", () => {
+    const issue = makeIssue({
+      body: "See https://stackoverflow.com/c/expensify/questions/1234",
+    });
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+  });
+
+  it("does not false-positive on normal text", () => {
+    const issue = makeIssue({
+      body: "The server returns a 500 error when clicking the button. Internal state is corrupted.",
+    });
+    // "internal" alone is NOT a keyword — "internal tool", "internal slack", etc. are
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(true);
+  });
+
+  it("detects keyword in body and comments combined", () => {
+    const issue = makeIssue({ body: "Use the staging server" });
+    const comments = [makeComment({ body: "Also needs VPN access" })];
+    const result = checkAccessRequirements(issue, comments, defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("staging server");
+    expect(result.detail).toContain("vpn");
+  });
+
+  it("passes when no keywords configured", () => {
+    const issue = makeIssue({ body: "Needs staging server" });
+    const result = checkAccessRequirements(issue, [], []);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// --- Proposal Counting ---
+
+describe("countProposals", () => {
+  it("counts comments containing proposal patterns", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nHere is my fix..." }),
+      makeComment({ body: "Great idea, +1" }),
+      makeComment({ body: "## Proposal\nAlternative approach..." }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.count).toBe(2);
+  });
+
+  it("counts alternative proposal patterns", () => {
+    const comments = [
+      makeComment({
+        body: "### Please re-state the problem\nThe button doesn't work",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.count).toBe(1);
+  });
+
+  it("returns 0 for no proposals", () => {
+    const comments = [makeComment({ body: "Just a regular comment" })];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.count).toBe(0);
+  });
+
+  it("returns 0 for empty comments", () => {
+    const result = countProposals([], defaultProposalPatterns);
+    expect(result.count).toBe(0);
+    expect(result.hasApproved).toBe(false);
+  });
+
+  it("detects approved proposal from MEMBER comment", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "MEMBER",
+        body: "Great proposal — you're hired!",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.hasApproved).toBe(true);
+  });
+
+  it("detects approved proposal from OWNER comment", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "OWNER",
+        body: "Offer sent, please check your email",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.hasApproved).toBe(true);
+  });
+
+  it("detects approved proposal from COLLABORATOR comment", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "COLLABORATOR",
+        body: "Approved! Please start working on it",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.hasApproved).toBe(true);
+  });
+
+  it("ignores approval phrases from non-maintainers", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "NONE",
+        body: "I think they should be hired! You're hired in my eyes",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.hasApproved).toBe(false);
+  });
+
+  it("ignores approval phrases from CONTRIBUTOR", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "CONTRIBUTOR",
+        body: "Approved by me!",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.hasApproved).toBe(false);
+  });
+
+  it("is case-insensitive for proposal pattern matching", () => {
+    const comments = [
+      makeComment({ body: "## proposal\nmy approach..." }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.count).toBe(1);
+  });
+});
+
+// --- Competition ---
+
+describe("checkCompetition", () => {
+  it("passes when proposals are below threshold", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nFix here" }),
+      makeComment({ body: "Just a question" }),
+    ];
+    const result = checkCompetition(comments, defaultProposalPatterns, 3);
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when proposals meet threshold", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({ body: "## Proposal\nFix 2" }),
+      makeComment({ body: "## Proposal\nFix 3" }),
+    ];
+    const result = checkCompetition(comments, defaultProposalPatterns, 3);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("3 >= 3");
+  });
+
+  it("fails when proposals exceed threshold", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({ body: "## Proposal\nFix 2" }),
+      makeComment({ body: "## Proposal\nFix 3" }),
+      makeComment({ body: "## Proposal\nFix 4" }),
+    ];
+    const result = checkCompetition(comments, defaultProposalPatterns, 3);
+    expect(result.passed).toBe(false);
+  });
+
+  it("fails instantly when a proposal is approved", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({
+        authorAssociation: "MEMBER",
+        body: "You're hired!",
+      }),
+    ];
+    const result = checkCompetition(comments, defaultProposalPatterns, 10);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("approved/hired");
+  });
+
+  it("passes when disabled (maxProposals = 0)", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({ body: "## Proposal\nFix 2" }),
+      makeComment({ body: "## Proposal\nFix 3" }),
+      makeComment({ body: "## Proposal\nFix 4" }),
+      makeComment({ body: "## Proposal\nFix 5" }),
+    ];
+    const result = checkCompetition(comments, defaultProposalPatterns, 0);
+    expect(result.passed).toBe(true);
+    expect(result.detail).toContain("disabled");
+  });
+
+  it("passes with no comments", () => {
+    const result = checkCompetition([], defaultProposalPatterns, 3);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// --- Bounty Confirmation ---
+
+describe("checkBountyConfirmation", () => {
+  it("always passes for Algora issues", () => {
+    const issue = makeIssue({
+      source: "algora",
+      bounty_amount: undefined,
+      labels: [],
+    });
+    const result = checkBountyConfirmation(issue, true, ["Help Wanted"]);
+    expect(result.passed).toBe(true);
+    expect(result.detail).toContain("Algora");
+  });
+
+  it("passes when disabled (requireLabel = false)", () => {
+    const issue = makeIssue({ bounty_amount: undefined, labels: [] });
+    const result = checkBountyConfirmation(issue, false, ["Help Wanted"]);
+    expect(result.passed).toBe(true);
+  });
+
+  it("passes when issue has bounty amount", () => {
+    const issue = makeIssue({ bounty_amount: 500 });
+    const result = checkBountyConfirmation(issue, true, ["Help Wanted"]);
+    expect(result.passed).toBe(true);
+    expect(result.detail).toContain("$500");
+  });
+
+  it("passes when issue has bounty label", () => {
+    const issue = makeIssue({
+      bounty_amount: undefined,
+      labels: ["Help Wanted", "Bug"],
+    });
+    const result = checkBountyConfirmation(issue, true, ["Help Wanted"]);
+    expect(result.passed).toBe(true);
+    expect(result.detail).toContain("bounty label");
+  });
+
+  it("bounty label check is case-insensitive", () => {
+    const issue = makeIssue({
+      bounty_amount: undefined,
+      labels: ["help wanted"],
+    });
+    const result = checkBountyConfirmation(issue, true, ["Help Wanted"]);
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when no bounty amount and no bounty label", () => {
+    const issue = makeIssue({
+      bounty_amount: undefined,
+      labels: ["Bug", "Enhancement"],
+    });
+    const result = checkBountyConfirmation(issue, true, ["Help Wanted"]);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("No bounty amount");
+  });
+});
+
+// --- Platform Requirements ---
+
+describe("checkPlatformRequirements", () => {
+  it("passes when no platform keywords configured", () => {
+    const issue = makeIssue({ body: "Anything goes" });
+    const result = checkPlatformRequirements(issue, []);
+    expect(result.passed).toBe(true);
+  });
+
+  it("fails when keyword found in body", () => {
+    const issue = makeIssue({ body: "This requires iOS 17+ only" });
+    const result = checkPlatformRequirements(issue, ["iOS 17"]);
+    expect(result.passed).toBe(false);
+    expect(result.detail).toContain("iOS 17");
+  });
+
+  it("fails when keyword found in title", () => {
+    const issue = makeIssue({ title: "[Android] Fix native crash" });
+    const result = checkPlatformRequirements(issue, ["[Android]"]);
+    expect(result.passed).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    const issue = makeIssue({ body: "Only affects WINDOWS users" });
+    const result = checkPlatformRequirements(issue, ["windows"]);
+    expect(result.passed).toBe(false);
+  });
+
+  it("passes when keywords not present", () => {
+    const issue = makeIssue({ body: "Web-only CSS bug", title: "Fix CSS" });
+    const result = checkPlatformRequirements(issue, ["iOS", "Android"]);
+    expect(result.passed).toBe(true);
+  });
+});
+
+// --- Orchestrator ---
+
+describe("vetIssue", () => {
+  it("passes when all checks pass", () => {
+    const issue = makeIssue({ body: "Simple bug", bounty_amount: 250 });
+    const result = vetIssue(issue, [], defaultVettingConfig);
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe("Vetted: OK");
+    expect(result.proposal_count).toBe(0);
+    expect(result.has_approved_proposal).toBe(false);
+    expect(result.access_keywords_found).toEqual([]);
+    expect(result.platform_keywords_found).toEqual([]);
+  });
+
+  it("fails when access requirements fail", () => {
+    const issue = makeIssue({
+      body: "Log into the staging server and test",
+    });
+    const result = vetIssue(issue, [], defaultVettingConfig);
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain("access_requirements");
+    expect(result.access_keywords_found).toContain("staging server");
+  });
+
+  it("fails when competition check fails", () => {
+    const issue = makeIssue();
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({ body: "## Proposal\nFix 2" }),
+      makeComment({ body: "## Proposal\nFix 3" }),
+    ];
+    const result = vetIssue(issue, comments, defaultVettingConfig);
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain("competition");
+    expect(result.proposal_count).toBe(3);
+  });
+
+  it("fails when multiple checks fail", () => {
+    const issue = makeIssue({
+      body: "Log into the staging server",
+    });
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({ body: "## Proposal\nFix 2" }),
+      makeComment({ body: "## Proposal\nFix 3" }),
+    ];
+    const result = vetIssue(issue, comments, defaultVettingConfig);
+    expect(result.passed).toBe(false);
+    expect(result.summary).toContain("access_requirements");
+    expect(result.summary).toContain("competition");
+  });
+
+  it("includes correct proposal count in result", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({ body: "Just commenting" }),
+      makeComment({ body: "## Proposal\nFix 2" }),
+    ];
+    const result = vetIssue(makeIssue(), comments, defaultVettingConfig);
+    expect(result.proposal_count).toBe(2);
+  });
+
+  it("detects approved proposals", () => {
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({
+        authorAssociation: "MEMBER",
+        body: "Great, you're hired!",
+      }),
+    ];
+    const result = vetIssue(makeIssue(), comments, defaultVettingConfig);
+    expect(result.has_approved_proposal).toBe(true);
+    expect(result.passed).toBe(false);
+  });
+
+  it("generates correct summary for all-pass", () => {
+    const result = vetIssue(makeIssue(), [], defaultVettingConfig);
+    expect(result.summary).toBe("Vetted: OK");
+    expect(result.signals.every((s) => s.passed)).toBe(true);
+  });
+
+  it("generates correct summary listing failed signal names", () => {
+    const issue = makeIssue({ body: "Needs staging server access" });
+    const config: VettingConfig = {
+      ...defaultVettingConfig,
+      platform_keywords: ["staging"],
+    };
+    const result = vetIssue(issue, [], config);
+    expect(result.passed).toBe(false);
+    // Both access_requirements and platform_requirements should fail
+    expect(result.summary).toContain("access_requirements");
+    expect(result.summary).toContain("platform_requirements");
+  });
+
+  it("uses custom config overrides", () => {
+    const issue = makeIssue();
+    const comments = [
+      makeComment({ body: "## Proposal\nFix 1" }),
+      makeComment({ body: "## Proposal\nFix 2" }),
+      makeComment({ body: "## Proposal\nFix 3" }),
+      makeComment({ body: "## Proposal\nFix 4" }),
+      makeComment({ body: "## Proposal\nFix 5" }),
+    ];
+    // Raise the threshold so it passes
+    const config: VettingConfig = {
+      ...defaultVettingConfig,
+      max_proposals: 10,
+    };
+    const result = vetIssue(issue, comments, config);
+    expect(result.passed).toBe(true);
+    expect(result.proposal_count).toBe(5);
+  });
+});

--- a/src/vet.test.ts
+++ b/src/vet.test.ts
@@ -84,6 +84,7 @@ describe("checkAccessRequirements", () => {
     const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
     expect(result.passed).toBe(false);
     expect(result.detail).toContain("staging server");
+    expect(result.found).toContain("staging server");
   });
 
   it("fails when keyword found in comments", () => {
@@ -95,7 +96,7 @@ describe("checkAccessRequirements", () => {
     ];
     const result = checkAccessRequirements(issue, comments, defaultAccessKeywords);
     expect(result.passed).toBe(false);
-    expect(result.detail).toContain("internal tool");
+    expect(result.found).toContain("internal tool");
   });
 
   it("is case-insensitive", () => {
@@ -110,7 +111,7 @@ describe("checkAccessRequirements", () => {
     });
     const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
     expect(result.passed).toBe(false);
-    expect(result.detail).toContain("internal URL pattern");
+    expect(result.found).toContain("internal URL pattern");
   });
 
   it("detects internal URL patterns (*.corp.*)", () => {
@@ -119,7 +120,7 @@ describe("checkAccessRequirements", () => {
     });
     const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
     expect(result.passed).toBe(false);
-    expect(result.detail).toContain("internal URL pattern");
+    expect(result.found).toContain("internal URL pattern");
   });
 
   it("detects stackoverflow.com/c/ (private Teams SO)", () => {
@@ -128,6 +129,17 @@ describe("checkAccessRequirements", () => {
     });
     const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
     expect(result.passed).toBe(false);
+  });
+
+  it("does not double-count stackoverflow.com/c/ from keyword + regex match", () => {
+    const issue = makeIssue({
+      body: "See https://stackoverflow.com/c/expensify/q/123",
+    });
+    const result = checkAccessRequirements(issue, [], defaultAccessKeywords);
+    expect(result.passed).toBe(false);
+    // Should only appear once, not twice
+    const soMatches = result.found!.filter((f) => f.includes("stackoverflow"));
+    expect(soMatches).toHaveLength(1);
   });
 
   it("does not false-positive on normal text", () => {
@@ -139,13 +151,15 @@ describe("checkAccessRequirements", () => {
     expect(result.passed).toBe(true);
   });
 
-  it("detects keyword in body and comments combined", () => {
-    const issue = makeIssue({ body: "Use the staging server" });
-    const comments = [makeComment({ body: "Also needs VPN access" })];
+  it("populates found array with all detected keywords", () => {
+    const issue = makeIssue({ body: "Use the staging server and VPN" });
+    const comments = [makeComment({ body: "Also check internal wiki" })];
     const result = checkAccessRequirements(issue, comments, defaultAccessKeywords);
     expect(result.passed).toBe(false);
-    expect(result.detail).toContain("staging server");
-    expect(result.detail).toContain("vpn");
+    expect(result.found).toContain("staging server");
+    expect(result.found).toContain("vpn");
+    expect(result.found).toContain("internal wiki");
+    expect(result.found!.length).toBeGreaterThanOrEqual(3);
   });
 
   it("passes when no keywords configured", () => {
@@ -216,7 +230,7 @@ describe("countProposals", () => {
     const comments = [
       makeComment({
         authorAssociation: "COLLABORATOR",
-        body: "Approved! Please start working on it",
+        body: "We have approved your proposal!",
       }),
     ];
     const result = countProposals(comments, defaultProposalPatterns);
@@ -238,7 +252,18 @@ describe("countProposals", () => {
     const comments = [
       makeComment({
         authorAssociation: "CONTRIBUTOR",
-        body: "Approved by me!",
+        body: "Proposal approved by me!",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.hasApproved).toBe(false);
+  });
+
+  it("does not false-positive on generic 'approved' without proposal context", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "MEMBER",
+        body: "Design approved, moving to implementation",
       }),
     ];
     const result = countProposals(comments, defaultProposalPatterns);
@@ -252,70 +277,53 @@ describe("countProposals", () => {
     const result = countProposals(comments, defaultProposalPatterns);
     expect(result.count).toBe(1);
   });
+
+  it("handles a comment that is both a proposal and an approval", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "MEMBER",
+        body: "## Proposal\nApproved your proposal! This is the way to go.",
+      }),
+    ];
+    const result = countProposals(comments, defaultProposalPatterns);
+    expect(result.count).toBe(1);
+    expect(result.hasApproved).toBe(true);
+  });
 });
 
 // --- Competition ---
 
 describe("checkCompetition", () => {
   it("passes when proposals are below threshold", () => {
-    const comments = [
-      makeComment({ body: "## Proposal\nFix here" }),
-      makeComment({ body: "Just a question" }),
-    ];
-    const result = checkCompetition(comments, defaultProposalPatterns, 3);
+    const result = checkCompetition({ count: 1, hasApproved: false }, 3);
     expect(result.passed).toBe(true);
   });
 
   it("fails when proposals meet threshold", () => {
-    const comments = [
-      makeComment({ body: "## Proposal\nFix 1" }),
-      makeComment({ body: "## Proposal\nFix 2" }),
-      makeComment({ body: "## Proposal\nFix 3" }),
-    ];
-    const result = checkCompetition(comments, defaultProposalPatterns, 3);
+    const result = checkCompetition({ count: 3, hasApproved: false }, 3);
     expect(result.passed).toBe(false);
     expect(result.detail).toContain("3 >= 3");
   });
 
   it("fails when proposals exceed threshold", () => {
-    const comments = [
-      makeComment({ body: "## Proposal\nFix 1" }),
-      makeComment({ body: "## Proposal\nFix 2" }),
-      makeComment({ body: "## Proposal\nFix 3" }),
-      makeComment({ body: "## Proposal\nFix 4" }),
-    ];
-    const result = checkCompetition(comments, defaultProposalPatterns, 3);
+    const result = checkCompetition({ count: 4, hasApproved: false }, 3);
     expect(result.passed).toBe(false);
   });
 
   it("fails instantly when a proposal is approved", () => {
-    const comments = [
-      makeComment({ body: "## Proposal\nFix 1" }),
-      makeComment({
-        authorAssociation: "MEMBER",
-        body: "You're hired!",
-      }),
-    ];
-    const result = checkCompetition(comments, defaultProposalPatterns, 10);
+    const result = checkCompetition({ count: 1, hasApproved: true }, 10);
     expect(result.passed).toBe(false);
     expect(result.detail).toContain("approved/hired");
   });
 
   it("passes when disabled (maxProposals = 0)", () => {
-    const comments = [
-      makeComment({ body: "## Proposal\nFix 1" }),
-      makeComment({ body: "## Proposal\nFix 2" }),
-      makeComment({ body: "## Proposal\nFix 3" }),
-      makeComment({ body: "## Proposal\nFix 4" }),
-      makeComment({ body: "## Proposal\nFix 5" }),
-    ];
-    const result = checkCompetition(comments, defaultProposalPatterns, 0);
+    const result = checkCompetition({ count: 5, hasApproved: false }, 0);
     expect(result.passed).toBe(true);
     expect(result.detail).toContain("disabled");
   });
 
-  it("passes with no comments", () => {
-    const result = checkCompetition([], defaultProposalPatterns, 3);
+  it("passes with zero proposals", () => {
+    const result = checkCompetition({ count: 0, hasApproved: false }, 3);
     expect(result.passed).toBe(true);
   });
 });
@@ -375,6 +383,15 @@ describe("checkBountyConfirmation", () => {
     expect(result.passed).toBe(false);
     expect(result.detail).toContain("No bounty amount");
   });
+
+  it("fails when bounty_amount is 0 and no bounty label present", () => {
+    const issue = makeIssue({
+      bounty_amount: 0,
+      labels: ["Bug"],
+    });
+    const result = checkBountyConfirmation(issue, true, ["Help Wanted"]);
+    expect(result.passed).toBe(false);
+  });
 });
 
 // --- Platform Requirements ---
@@ -390,7 +407,7 @@ describe("checkPlatformRequirements", () => {
     const issue = makeIssue({ body: "This requires iOS 17+ only" });
     const result = checkPlatformRequirements(issue, ["iOS 17"]);
     expect(result.passed).toBe(false);
-    expect(result.detail).toContain("iOS 17");
+    expect(result.found).toContain("iOS 17");
   });
 
   it("fails when keyword found in title", () => {
@@ -410,6 +427,13 @@ describe("checkPlatformRequirements", () => {
     const result = checkPlatformRequirements(issue, ["iOS", "Android"]);
     expect(result.passed).toBe(true);
   });
+
+  it("does not check comments (by design — platform tags are in issue metadata)", () => {
+    // checkPlatformRequirements only takes issue, not comments
+    const issue = makeIssue({ body: "Simple bug", title: "Fix crash" });
+    const result = checkPlatformRequirements(issue, ["iOS"]);
+    expect(result.passed).toBe(true);
+  });
 });
 
 // --- Orchestrator ---
@@ -422,8 +446,6 @@ describe("vetIssue", () => {
     expect(result.summary).toBe("Vetted: OK");
     expect(result.proposal_count).toBe(0);
     expect(result.has_approved_proposal).toBe(false);
-    expect(result.access_keywords_found).toEqual([]);
-    expect(result.platform_keywords_found).toEqual([]);
   });
 
   it("fails when access requirements fail", () => {
@@ -433,7 +455,19 @@ describe("vetIssue", () => {
     const result = vetIssue(issue, [], defaultVettingConfig);
     expect(result.passed).toBe(false);
     expect(result.summary).toContain("access_requirements");
-    expect(result.access_keywords_found).toContain("staging server");
+    const accessSignal = result.signals.find((s) => s.name === "access_requirements");
+    expect(accessSignal?.found).toContain("staging server");
+  });
+
+  it("populates found keywords on access signal via orchestrator", () => {
+    const issue = makeIssue({
+      body: "Needs VPN access and the staging server credentials",
+    });
+    const result = vetIssue(issue, [], defaultVettingConfig);
+    const accessSignal = result.signals.find((s) => s.name === "access_requirements");
+    expect(accessSignal?.found).toContain("vpn");
+    expect(accessSignal?.found).toContain("staging server");
+    expect(accessSignal!.found!.length).toBeGreaterThanOrEqual(2);
   });
 
   it("fails when competition check fails", () => {

--- a/src/vet.test.ts
+++ b/src/vet.test.ts
@@ -162,10 +162,25 @@ describe("checkAccessRequirements", () => {
     expect(result.found!.length).toBeGreaterThanOrEqual(3);
   });
 
-  it("passes when no keywords configured", () => {
+  it("passes when no keywords configured and no internal URLs", () => {
     const issue = makeIssue({ body: "Needs staging server" });
     const result = checkAccessRequirements(issue, [], []);
+    // "staging server" is not a configured keyword, and no internal URL patterns present
     expect(result.passed).toBe(true);
+  });
+
+  it("still detects internal URL patterns even with empty keywords", () => {
+    const issue = makeIssue({ body: "See dashboard.internal.company.com" });
+    const result = checkAccessRequirements(issue, [], []);
+    expect(result.passed).toBe(false);
+    expect(result.found).toContain("internal URL pattern");
+  });
+
+  it("still detects *.corp.* URLs even with empty keywords", () => {
+    const issue = makeIssue({ body: "Visit tools.corp.example.com" });
+    const result = checkAccessRequirements(issue, [], []);
+    expect(result.passed).toBe(false);
+    expect(result.found).toContain("internal URL pattern");
   });
 });
 
@@ -289,6 +304,18 @@ describe("countProposals", () => {
     expect(result.count).toBe(1);
     expect(result.hasApproved).toBe(true);
   });
+
+  it("counts zero proposals but still detects approvals when patterns is empty", () => {
+    const comments = [
+      makeComment({
+        authorAssociation: "MEMBER",
+        body: "You're hired!",
+      }),
+    ];
+    const result = countProposals(comments, []);
+    expect(result.count).toBe(0);
+    expect(result.hasApproved).toBe(true);
+  });
 });
 
 // --- Competition ---
@@ -325,6 +352,12 @@ describe("checkCompetition", () => {
   it("passes with zero proposals", () => {
     const result = checkCompetition({ count: 0, hasApproved: false }, 3);
     expect(result.passed).toBe(true);
+  });
+
+  it("passes when disabled even if a proposal is approved", () => {
+    const result = checkCompetition({ count: 1, hasApproved: true }, 0);
+    expect(result.passed).toBe(true);
+    expect(result.detail).toContain("disabled");
   });
 });
 

--- a/src/vet.ts
+++ b/src/vet.ts
@@ -1,5 +1,6 @@
 import type {
   BountyIssue,
+  GitHubAuthorAssociation,
   IssueComment,
   VetSignal,
   VetResult,
@@ -10,16 +11,19 @@ import type {
 const INTERNAL_URL_RE = /\b\w+\.(internal|corp)\.\w+/i;
 const INTERNAL_SO_RE = /stackoverflow\.com\/c\//i;
 
-// Phrases from maintainers that indicate someone is already hired/approved
+// Phrases from maintainers that indicate someone is already hired/approved.
+// These are intentionally specific to avoid false positives — a maintainer
+// saying "design approved" or "PR approved" should NOT trigger this.
 const APPROVED_PHRASES = [
   "you're hired",
   "you are hired",
   "offer sent",
-  "approved",
+  "proposal approved",
+  "approved your proposal",
   "assigned to you",
 ];
 
-const MAINTAINER_ASSOCIATIONS = new Set([
+const MAINTAINER_ASSOCIATIONS: ReadonlySet<GitHubAuthorAssociation> = new Set([
   "MEMBER",
   "OWNER",
   "COLLABORATOR",
@@ -27,6 +31,8 @@ const MAINTAINER_ASSOCIATIONS = new Set([
 
 /**
  * Checks if the issue body or comments reference internal/private access tools.
+ * Matches against both configurable keywords and hardcoded URL patterns
+ * (*.internal.*, *.corp.*, stackoverflow.com/c/).
  */
 export function checkAccessRequirements(
   issue: BountyIssue,
@@ -69,6 +75,7 @@ export function checkAccessRequirements(
       name: "access_requirements",
       passed: false,
       detail: `Found access keywords: ${found.join(", ")}`,
+      found,
     };
   }
 
@@ -113,10 +120,10 @@ export function countProposals(
 
 /**
  * Checks if there are too many competing proposals or if someone is already hired.
+ * Accepts pre-computed proposal stats to avoid redundant iteration.
  */
 export function checkCompetition(
-  comments: IssueComment[],
-  patterns: string[],
+  proposalStats: { count: number; hasApproved: boolean },
   maxProposals: number
 ): VetSignal {
   // max_proposals = 0 means disabled
@@ -124,7 +131,7 @@ export function checkCompetition(
     return { name: "competition", passed: true, detail: "Competition check disabled" };
   }
 
-  const { count, hasApproved } = countProposals(comments, patterns);
+  const { count, hasApproved } = proposalStats;
 
   if (hasApproved) {
     return {
@@ -189,7 +196,8 @@ export function checkBountyConfirmation(
 }
 
 /**
- * Checks if the issue body mentions platform-specific requirements.
+ * Checks if the issue title or body mentions platform-specific requirements.
+ * Does not check comments — platform tags are typically in issue metadata.
  */
 export function checkPlatformRequirements(
   issue: BountyIssue,
@@ -213,6 +221,7 @@ export function checkPlatformRequirements(
       name: "platform_requirements",
       passed: false,
       detail: `Platform requirements found: ${found.join(", ")}`,
+      found,
     };
   }
 
@@ -227,9 +236,12 @@ export function vetIssue(
   comments: IssueComment[],
   config: VettingConfig
 ): VetResult {
+  // Count proposals once, share with competition check
+  const proposalStats = countProposals(comments, config.proposal_patterns);
+
   const signals: VetSignal[] = [
     checkAccessRequirements(issue, comments, config.access_keywords),
-    checkCompetition(comments, config.proposal_patterns, config.max_proposals),
+    checkCompetition(proposalStats, config.max_proposals),
     checkBountyConfirmation(
       issue,
       config.require_bounty_label,
@@ -237,21 +249,6 @@ export function vetIssue(
     ),
     checkPlatformRequirements(issue, config.platform_keywords),
   ];
-
-  const { count, hasApproved } = countProposals(
-    comments,
-    config.proposal_patterns
-  );
-
-  const accessSignal = signals.find((s) => s.name === "access_requirements")!;
-  const platformSignal = signals.find((s) => s.name === "platform_requirements")!;
-
-  const accessKeywordsFound = accessSignal.passed
-    ? []
-    : extractKeywordsFromDetail(accessSignal.detail);
-  const platformKeywordsFound = platformSignal.passed
-    ? []
-    : extractKeywordsFromDetail(platformSignal.detail);
 
   const passed = signals.every((s) => s.passed);
   const failedSignals = signals.filter((s) => !s.passed);
@@ -263,16 +260,8 @@ export function vetIssue(
   return {
     passed,
     signals,
-    proposal_count: count,
-    has_approved_proposal: hasApproved,
-    access_keywords_found: accessKeywordsFound,
-    platform_keywords_found: platformKeywordsFound,
+    proposal_count: proposalStats.count,
+    has_approved_proposal: proposalStats.hasApproved,
     summary,
   };
-}
-
-function extractKeywordsFromDetail(detail: string): string[] {
-  const match = detail.match(/: (.+)$/);
-  if (!match) return [];
-  return match[1].split(", ");
 }

--- a/src/vet.ts
+++ b/src/vet.ts
@@ -1,0 +1,278 @@
+import type {
+  BountyIssue,
+  IssueComment,
+  VetSignal,
+  VetResult,
+  VettingConfig,
+} from "./types.js";
+
+// Internal URL patterns that suggest the issue requires private access
+const INTERNAL_URL_RE = /\b\w+\.(internal|corp)\.\w+/i;
+const INTERNAL_SO_RE = /stackoverflow\.com\/c\//i;
+
+// Phrases from maintainers that indicate someone is already hired/approved
+const APPROVED_PHRASES = [
+  "you're hired",
+  "you are hired",
+  "offer sent",
+  "approved",
+  "assigned to you",
+];
+
+const MAINTAINER_ASSOCIATIONS = new Set([
+  "MEMBER",
+  "OWNER",
+  "COLLABORATOR",
+]);
+
+/**
+ * Checks if the issue body or comments reference internal/private access tools.
+ */
+export function checkAccessRequirements(
+  issue: BountyIssue,
+  comments: IssueComment[],
+  keywords: string[]
+): VetSignal {
+  if (keywords.length === 0) {
+    return { name: "access_requirements", passed: true, detail: "No access keywords configured" };
+  }
+
+  const allText = [
+    issue.body,
+    ...comments.map((c) => c.body),
+  ]
+    .join("\n")
+    .toLowerCase();
+
+  const found: string[] = [];
+
+  for (const kw of keywords) {
+    if (allText.includes(kw.toLowerCase())) {
+      found.push(kw);
+    }
+  }
+
+  // Also check for internal URL patterns
+  const fullText = [issue.body, ...comments.map((c) => c.body)].join("\n");
+  if (INTERNAL_URL_RE.test(fullText)) {
+    found.push("internal URL pattern");
+  }
+  if (INTERNAL_SO_RE.test(fullText)) {
+    // Only add if "stackoverflow.com/c/" wasn't already matched as a keyword
+    if (!found.some((f) => f.toLowerCase().includes("stackoverflow.com/c/"))) {
+      found.push("stackoverflow.com/c/");
+    }
+  }
+
+  if (found.length > 0) {
+    return {
+      name: "access_requirements",
+      passed: false,
+      detail: `Found access keywords: ${found.join(", ")}`,
+    };
+  }
+
+  return { name: "access_requirements", passed: true, detail: "No access issues detected" };
+}
+
+/**
+ * Counts proposals in issue comments using configurable heading patterns.
+ * Also detects approved/hired proposals from maintainer comments.
+ */
+export function countProposals(
+  comments: IssueComment[],
+  patterns: string[]
+): { count: number; hasApproved: boolean } {
+  let count = 0;
+  let hasApproved = false;
+
+  for (const comment of comments) {
+    const bodyLower = comment.body.toLowerCase();
+
+    // Check if this comment contains a proposal
+    const isProposal = patterns.some((p) =>
+      bodyLower.includes(p.toLowerCase())
+    );
+    if (isProposal) {
+      count++;
+    }
+
+    // Check if a maintainer has approved/hired someone
+    if (MAINTAINER_ASSOCIATIONS.has(comment.authorAssociation)) {
+      for (const phrase of APPROVED_PHRASES) {
+        if (bodyLower.includes(phrase)) {
+          hasApproved = true;
+          break;
+        }
+      }
+    }
+  }
+
+  return { count, hasApproved };
+}
+
+/**
+ * Checks if there are too many competing proposals or if someone is already hired.
+ */
+export function checkCompetition(
+  comments: IssueComment[],
+  patterns: string[],
+  maxProposals: number
+): VetSignal {
+  // max_proposals = 0 means disabled
+  if (maxProposals === 0) {
+    return { name: "competition", passed: true, detail: "Competition check disabled" };
+  }
+
+  const { count, hasApproved } = countProposals(comments, patterns);
+
+  if (hasApproved) {
+    return {
+      name: "competition",
+      passed: false,
+      detail: `A proposal has been approved/hired (${count} total proposals)`,
+    };
+  }
+
+  if (count >= maxProposals) {
+    return {
+      name: "competition",
+      passed: false,
+      detail: `Too many proposals: ${count} >= ${maxProposals}`,
+    };
+  }
+
+  return {
+    name: "competition",
+    passed: true,
+    detail: `${count} proposal(s), below threshold of ${maxProposals}`,
+  };
+}
+
+/**
+ * Checks that the issue actually has a confirmed bounty (amount or label).
+ * Always passes for Algora issues (bounties are confirmed by the platform).
+ */
+export function checkBountyConfirmation(
+  issue: BountyIssue,
+  requireLabel: boolean,
+  labels: string[]
+): VetSignal {
+  // Algora issues have platform-confirmed bounties
+  if (issue.source === "algora") {
+    return { name: "bounty_confirmation", passed: true, detail: "Algora bounty (platform-confirmed)" };
+  }
+
+  if (!requireLabel) {
+    return { name: "bounty_confirmation", passed: true, detail: "Bounty label check disabled" };
+  }
+
+  // Pass if the issue has a bounty amount
+  if (issue.bounty_amount && issue.bounty_amount > 0) {
+    return { name: "bounty_confirmation", passed: true, detail: `Bounty amount: $${issue.bounty_amount}` };
+  }
+
+  // Pass if the issue has a bounty label
+  const labelsLower = labels.map((l) => l.toLowerCase());
+  const hasLabel = issue.labels.some((l) =>
+    labelsLower.includes(l.toLowerCase())
+  );
+  if (hasLabel) {
+    return { name: "bounty_confirmation", passed: true, detail: "Has bounty label" };
+  }
+
+  return {
+    name: "bounty_confirmation",
+    passed: false,
+    detail: "No bounty amount and no bounty label found",
+  };
+}
+
+/**
+ * Checks if the issue body mentions platform-specific requirements.
+ */
+export function checkPlatformRequirements(
+  issue: BountyIssue,
+  keywords: string[]
+): VetSignal {
+  if (keywords.length === 0) {
+    return { name: "platform_requirements", passed: true, detail: "No platform keywords configured" };
+  }
+
+  const text = (issue.title + "\n" + issue.body).toLowerCase();
+  const found: string[] = [];
+
+  for (const kw of keywords) {
+    if (text.includes(kw.toLowerCase())) {
+      found.push(kw);
+    }
+  }
+
+  if (found.length > 0) {
+    return {
+      name: "platform_requirements",
+      passed: false,
+      detail: `Platform requirements found: ${found.join(", ")}`,
+    };
+  }
+
+  return { name: "platform_requirements", passed: true, detail: "No platform issues detected" };
+}
+
+/**
+ * Orchestrates all vetting checks and produces a summary result.
+ */
+export function vetIssue(
+  issue: BountyIssue,
+  comments: IssueComment[],
+  config: VettingConfig
+): VetResult {
+  const signals: VetSignal[] = [
+    checkAccessRequirements(issue, comments, config.access_keywords),
+    checkCompetition(comments, config.proposal_patterns, config.max_proposals),
+    checkBountyConfirmation(
+      issue,
+      config.require_bounty_label,
+      config.bounty_labels
+    ),
+    checkPlatformRequirements(issue, config.platform_keywords),
+  ];
+
+  const { count, hasApproved } = countProposals(
+    comments,
+    config.proposal_patterns
+  );
+
+  const accessSignal = signals.find((s) => s.name === "access_requirements")!;
+  const platformSignal = signals.find((s) => s.name === "platform_requirements")!;
+
+  const accessKeywordsFound = accessSignal.passed
+    ? []
+    : extractKeywordsFromDetail(accessSignal.detail);
+  const platformKeywordsFound = platformSignal.passed
+    ? []
+    : extractKeywordsFromDetail(platformSignal.detail);
+
+  const passed = signals.every((s) => s.passed);
+  const failedSignals = signals.filter((s) => !s.passed);
+
+  const summary = passed
+    ? "Vetted: OK"
+    : `Failed: ${failedSignals.map((s) => s.name).join(", ")}`;
+
+  return {
+    passed,
+    signals,
+    proposal_count: count,
+    has_approved_proposal: hasApproved,
+    access_keywords_found: accessKeywordsFound,
+    platform_keywords_found: platformKeywordsFound,
+    summary,
+  };
+}
+
+function extractKeywordsFromDetail(detail: string): string[] {
+  const match = detail.match(/: (.+)$/);
+  if (!match) return [];
+  return match[1].split(", ");
+}

--- a/src/vet.ts
+++ b/src/vet.ts
@@ -39,27 +39,18 @@ export function checkAccessRequirements(
   comments: IssueComment[],
   keywords: string[]
 ): VetSignal {
-  if (keywords.length === 0) {
-    return { name: "access_requirements", passed: true, detail: "No access keywords configured" };
-  }
-
-  const allText = [
-    issue.body,
-    ...comments.map((c) => c.body),
-  ]
-    .join("\n")
-    .toLowerCase();
-
+  const fullText = [issue.body, ...comments.map((c) => c.body)].join("\n");
+  const allText = fullText.toLowerCase();
   const found: string[] = [];
 
+  // Check configurable keywords
   for (const kw of keywords) {
     if (allText.includes(kw.toLowerCase())) {
       found.push(kw);
     }
   }
 
-  // Also check for internal URL patterns
-  const fullText = [issue.body, ...comments.map((c) => c.body)].join("\n");
+  // Always check hardcoded internal URL patterns regardless of keyword config
   if (INTERNAL_URL_RE.test(fullText)) {
     found.push("internal URL pattern");
   }

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -22,6 +22,34 @@ filters:
     - In Progress
   max_comment_count: 5         # Skip GitHub issues with >= N comments (0 = disabled)
 
+# Deep issue vetting (all optional — defaults shown)
+# Runs after cheap filters, analyzes issue body + fetched comments
+vetting:
+  enabled: true                # Master toggle for vetting
+  on_fail: "skip"              # "skip" = silent drop, "warn" = notify with warning, "notify_all" = ignore failures
+  max_proposals: 3             # Fail if >= N proposals already exist (0 = disabled)
+  require_bounty_label: false  # Require bounty amount OR label to pass
+  bounty_labels:               # Labels that confirm a bounty (when require_bounty_label is true)
+    - "Help Wanted"
+  access_keywords:             # Keywords indicating internal/private access required
+    - "staging server"
+    - "staging environment"
+    - "internal tool"
+    - "internal slack"
+    - "internal stack overflow"
+    - "stackoverflow.com/c/"
+    - "vpn"
+    - "internal wiki"
+    - "century"
+    - "admin console"
+    - "internal dashboard"
+    - "dev environment"
+    - "test account provided"
+  platform_keywords: []        # Keywords for platform-specific requirements (e.g., "iOS", "Android")
+  proposal_patterns:           # Patterns that identify a proposal comment
+    - "## Proposal"
+    - "### Please re-state the problem"
+
 sources:
   repos:
     - name: Expensify/App


### PR DESCRIPTION
## Summary

- Adds a rule-based **issue vetting step** that runs after cheap filters (dedup, pre-filter, freshness) and before Telegram notifications
- Five independent checks: **access requirements** (internal tools/URLs), **competition** (proposal count + hired detection), **bounty confirmation** (amount or label), **platform requirements** (configurable keywords), and **proposal counting** (pattern-matched from comments)
- Configurable via `watchlist.yml` `vetting:` section with three `on_fail` modes: `skip` (default, silent drop), `warn` (notify with warning), `notify_all` (ignore failures)
- Enriches Telegram notifications with verified proposal count and vetting status emoji
- Error-safe: broken vetting (e.g. API failure fetching comments) never silently drops bounties

### New pipeline
```
fetch → dedup → pre-filter → freshness → [VET] → notify (or skip)
```

### Files changed
| File | Change |
|---|---|
| `src/vet.ts` | **New** — 5 check functions + orchestrator (46 tests) |
| `src/vet.test.ts` | **New** — comprehensive test suite |
| `src/types.ts` | `IssueComment`, `VetSignal`, `VetResult`, `VettingConfigSchema` |
| `src/github.ts` | `fetchIssueComments()` + `buildIssueViewArgs()` |
| `src/telegram.ts` | `formatBountyNotification(issue, vetResult?)` — backwards-compatible |
| `src/monitor.ts` | Vetting integration + `shouldNotify()` |
| `src/index.ts` | Scan command includes `vetResult` in output |
| `watchlist.example.yml` | Documented vetting config section |
| `CLAUDE.md` | Updated architecture docs |
| `*test.ts` files | +14 new tests across existing test files |

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `npx vitest run` — 109 tests pass (up from 32)
- [ ] Manual: `bounty-hunter scan --json` shows `vetResult` in output
- [ ] Manual: Known "bad" issue (internal access keywords) would be skipped
- [ ] Manual: Known "good" issue passes with "Vetted: OK"

🤖 Generated with [Claude Code](https://claude.com/claude-code)