### PR TITLE
Expand bounty discovery: GitHub Global Search, Algora pagination, source types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
 
 ## Project Overview
 
-Claude Code plugin that monitors GitHub repos and Algora for open bounty issues, sends Telegram notifications, and provides an AI-assisted `/claim` workflow to investigate codebases and draft proposals.
+Claude Code plugin that monitors GitHub repos, Algora, and GitHub Global Search for open bounty issues, sends Telegram notifications, and provides an AI-assisted `/claim` workflow to investigate codebases and draft proposals.
 
 Two modes of operation:
 - **Background monitor** (no AI): standalone Node.js script run by launchd, polls APIs on a timer
@@ -36,7 +36,7 @@ Two modes of operation:
 ```bash
 npm install
 npm run build    # Compile TypeScript to dist/
-npx vitest run   # Run all tests (109+ tests across 9 files)
+npx vitest run   # Run all tests (140+ tests across 9 files)
 ```
 
 ## Architecture
@@ -47,6 +47,7 @@ src/
   config.ts              YAML config loader, data dir management (~/.bounty-hunter/)
   seen.ts                SeenStore — JSON-backed deduplication (seen.json)
   github.ts              GitHub issue fetcher + comment fetcher (wraps gh CLI via execFileSync)
+  github-search.ts       GitHub Global Search — search all of GitHub for bounty-labeled issues
   algora.ts              Algora tRPC client (public API, amounts in cents)
   telegram.ts            Telegram Bot API client (send messages, get updates, vet-enriched notifications)
   vet.ts                 Issue vetting — rule-based checks (access, competition, bounty, platform)
@@ -87,10 +88,11 @@ templates/
 
 ## Core Types (src/types.ts)
 
-- `BountyIssue` — normalized issue from GitHub or Algora (source, repo, number, title, url, bounty_amount, labels, body)
+- `BountyIssue` — normalized issue from GitHub, Algora, or GitHub Global Search (source: "github" | "algora" | "github_search")
 - `WatchlistConfig` — top-level config shape (polling_interval, telegram, sources, filters, vetting)
 - `RepoSource` — individual GitHub repo config (name, labels, proposal_template, pre_filter)
 - `AlgoraSource` — Algora config (enabled, min_bounty, languages, keywords_exclude)
+- `GitHubSearchSource` — GitHub Global Search config (enabled, labels, languages, min_stars, keywords_exclude, max_results)
 - `SeenIssue` — deduplication record (id, repo, number, title, seen_at, skipped)
 - `TelegramConfig` — bot_token + chat_id
 - `VettingConfig` — vetting rules (enabled, on_fail, max_proposals, access_keywords, platform_keywords, etc.)
@@ -104,12 +106,13 @@ templates/
 2. `monitor.ts` iterates repos: `fetchRepoIssues()` → `applyPreFilter()` → `applyFreshnessFilter()` → `seen.markSeenFromBounty()`
 3. `monitor.ts` vets survivors: `fetchIssueComments()` → `vetIssue()` → `shouldNotify()`
 4. `monitor.ts` polls Algora: `fetchAlgoraBounties(buildAlgoraFilters())` → freshness → vet (body-only, no comments)
+4.5. `monitor.ts` polls GitHub Global Search: `fetchGlobalBounties()` → dedup watched repos → `applyFreshnessFilter()` → `fetchIssueComments()` → `vetIssue()` → `shouldNotify()`
 5. New issues → `formatBountyNotification(issue, vetResult?)` → `sendTelegramMessage()`
 
 ## Testing
 
 - Tests live alongside source as `*.test.ts`
-- 109+ tests across 9 files
+- 140+ tests across 9 files
 - Integration test (`integration.test.ts`) hits real GitHub API via `gh` — requires `gh auth status`
 - Integration test overrides `HOME` to isolate config; preserves `GH_CONFIG_DIR` for auth
 - Run: `npx vitest run` (all tests) or `npx vitest run src/github.test.ts` (single file)

--- a/src/algora.test.ts
+++ b/src/algora.test.ts
@@ -151,6 +151,19 @@ describe("parseAlgoraResponse", () => {
   });
 });
 
+describe("buildAlgoraUrl with cursor", () => {
+  it("includes cursor in URL when provided", () => {
+    const url = buildAlgoraUrl({ cursor: "abc123" });
+    expect(url).toContain("abc123");
+  });
+
+  it("does not include cursor when null", () => {
+    const url = buildAlgoraUrl({ cursor: null });
+    const decoded = decodeURIComponent(url);
+    expect(decoded).not.toContain('"cursor"');
+  });
+});
+
 describe("buildAlgoraFilters", () => {
   it("converts AlgoraSource to filter params correctly", () => {
     const source: AlgoraSource = {
@@ -158,6 +171,7 @@ describe("buildAlgoraFilters", () => {
       min_bounty: 100,
       languages: ["typescript", "rust"],
       keywords_exclude: ["devops", "infra"],
+      max_pages: 3,
     };
     const filters = buildAlgoraFilters(source);
     expect(filters.min_bounty).toBe(100);
@@ -171,10 +185,23 @@ describe("buildAlgoraFilters", () => {
       min_bounty: 50,
       languages: [],
       keywords_exclude: [],
+      max_pages: 3,
     };
     const filters = buildAlgoraFilters(source);
     expect(filters.min_bounty).toBe(50);
     expect(filters.languages).toBeUndefined();
     expect(filters.keywords_exclude).toEqual([]);
+  });
+
+  it("passes max_pages through to filter params", () => {
+    const source: AlgoraSource = {
+      enabled: true,
+      min_bounty: 100,
+      languages: [],
+      keywords_exclude: [],
+      max_pages: 5,
+    };
+    const filters = buildAlgoraFilters(source);
+    expect(filters.max_pages).toBe(5);
   });
 });

--- a/src/algora.ts
+++ b/src/algora.ts
@@ -56,10 +56,16 @@ export function buildAlgoraUrl(params: AlgoraQueryParams): string {
 }
 
 function parseSingleResponse(raw: AlgoraResponse[]): { items: AlgoraItem[]; nextCursor: string | null } {
+  if (!raw.length) {
+    throw new Error("Algora API returned empty response array");
+  }
   const data = raw[0]?.result?.data?.json;
+  if (!data) {
+    throw new Error("Algora API response missing expected structure (result.data.json)");
+  }
   return {
-    items: data?.items ?? [],
-    nextCursor: data?.next_cursor ?? null,
+    items: data.items ?? [],
+    nextCursor: data.next_cursor ?? null,
   };
 }
 
@@ -124,10 +130,38 @@ export async function fetchAlgoraBounties(
 
   do {
     const url = buildAlgoraUrl({ limit: 50, cursor });
-    const response = await fetch(url);
-    if (!response.ok) throw new Error(`Algora API error: ${response.status}`);
-    const data = (await response.json()) as AlgoraResponse[];
-    const { items, nextCursor } = parseSingleResponse(data);
+    let response: Response;
+    try {
+      response = await fetch(url);
+    } catch (err) {
+      if (page === 0) throw new Error(`Algora API network error: ${err instanceof Error ? err.message : err}`);
+      console.error(`Algora API network error on page ${page + 1}. Returning ${allItems.length} items from previous pages.`);
+      break;
+    }
+    if (!response.ok) {
+      if (page === 0) throw new Error(`Algora API error: ${response.status}`);
+      console.error(`Algora API error ${response.status} on page ${page + 1}. Returning ${allItems.length} items from previous pages.`);
+      break;
+    }
+    let data: AlgoraResponse[];
+    try {
+      data = (await response.json()) as AlgoraResponse[];
+    } catch {
+      if (page === 0) throw new Error("Algora API returned invalid JSON");
+      console.error(`Algora API returned invalid JSON on page ${page + 1}. Returning ${allItems.length} items from previous pages.`);
+      break;
+    }
+    let items: AlgoraItem[];
+    let nextCursor: string | null;
+    try {
+      ({ items, nextCursor } = parseSingleResponse(data));
+    } catch (err) {
+      if (page === 0) throw err;
+      console.error(
+        `Algora API malformed response on page ${page + 1}. Returning ${allItems.length} items from previous pages.`
+      );
+      break;
+    }
     allItems.push(...items);
     cursor = nextCursor;
     page++;

--- a/src/algora.ts
+++ b/src/algora.ts
@@ -4,12 +4,14 @@ const ALGORA_BASE = "https://algora.io/api/trpc/bounty.list";
 
 interface AlgoraQueryParams {
   limit?: number;
+  cursor?: string | null;
 }
 
 interface AlgoraFilterParams {
   min_bounty?: number;
   languages?: string[];
   keywords_exclude?: string[];
+  max_pages?: number;
 }
 
 interface AlgoraItem {
@@ -42,25 +44,26 @@ interface AlgoraResponse {
 }
 
 export function buildAlgoraUrl(params: AlgoraQueryParams): string {
-  const input = {
-    "0": {
-      json: {
-        status: "open",
-        limit: params.limit ?? 50,
-
-
-      },
-    },
+  const json: Record<string, unknown> = {
+    status: "open",
+    limit: params.limit ?? 50,
   };
+  if (params.cursor) {
+    json.cursor = params.cursor;
+  }
+  const input = { "0": { json } };
   return `${ALGORA_BASE}?batch=1&input=${encodeURIComponent(JSON.stringify(input))}`;
 }
 
-export function parseAlgoraResponse(
-  raw: AlgoraResponse[],
-  filters?: AlgoraFilterParams
-): BountyIssue[] {
-  const items = raw[0]?.result?.data?.json?.items ?? [];
+function parseSingleResponse(raw: AlgoraResponse[]): { items: AlgoraItem[]; nextCursor: string | null } {
+  const data = raw[0]?.result?.data?.json;
+  return {
+    items: data?.items ?? [],
+    nextCursor: data?.next_cursor ?? null,
+  };
+}
 
+function applyAlgoraFilters(items: AlgoraItem[], filters?: AlgoraFilterParams): BountyIssue[] {
   return items
     .filter((item) => {
       if (filters?.min_bounty && item.reward.amount / 100 < filters.min_bounty) {
@@ -94,20 +97,41 @@ export function parseAlgoraResponse(
     }));
 }
 
+export function parseAlgoraResponse(
+  raw: AlgoraResponse[],
+  filters?: AlgoraFilterParams
+): BountyIssue[] {
+  const { items } = parseSingleResponse(raw);
+  return applyAlgoraFilters(items, filters);
+}
+
 export function buildAlgoraFilters(algora: AlgoraSource): AlgoraFilterParams {
   return {
     min_bounty: algora.min_bounty,
     languages: algora.languages.length ? algora.languages : undefined,
     keywords_exclude: algora.keywords_exclude,
+    max_pages: algora.max_pages,
   };
 }
 
 export async function fetchAlgoraBounties(
   filters?: AlgoraFilterParams
 ): Promise<BountyIssue[]> {
-  const url = buildAlgoraUrl({ limit: 50 });
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`Algora API error: ${response.status}`);
-  const data = (await response.json()) as AlgoraResponse[];
-  return parseAlgoraResponse(data, filters);
+  const maxPages = filters?.max_pages ?? 3;
+  const allItems: AlgoraItem[] = [];
+  let cursor: string | null = null;
+  let page = 0;
+
+  do {
+    const url = buildAlgoraUrl({ limit: 50, cursor });
+    const response = await fetch(url);
+    if (!response.ok) throw new Error(`Algora API error: ${response.status}`);
+    const data = (await response.json()) as AlgoraResponse[];
+    const { items, nextCursor } = parseSingleResponse(data);
+    allItems.push(...items);
+    cursor = nextCursor;
+    page++;
+  } while (cursor && page < maxPages);
+
+  return applyAlgoraFilters(allItems, filters);
 }

--- a/src/github-search.test.ts
+++ b/src/github-search.test.ts
@@ -28,7 +28,7 @@ function mockSearchResult(overrides: Partial<Record<string, unknown>> = {}) {
 
 describe("buildGlobalSearchArgs", () => {
   it("builds correct base flags", () => {
-    const args = buildGlobalSearchArgs(defaultConfig);
+    const args = buildGlobalSearchArgs(defaultConfig, "bounty");
     expect(args).toContain("search");
     expect(args).toContain("issues");
     expect(args).toContain("--state");
@@ -36,36 +36,44 @@ describe("buildGlobalSearchArgs", () => {
     expect(args).toContain("--limit");
   });
 
-  it("adds individual --label flags for multiple labels", () => {
-    const config = { ...defaultConfig, labels: ["bounty", "\u{1F4B0} bounty"] };
-    const args = buildGlobalSearchArgs(config);
-    const labelFlags = args.reduce((count, arg) => arg === "--label" ? count + 1 : count, 0);
-    expect(labelFlags).toBe(2);
-    expect(args).toContain("bounty");
-    expect(args).toContain("\u{1F4B0} bounty");
+  it("includes the given label as --label flag", () => {
+    const args = buildGlobalSearchArgs(defaultConfig, "bounty");
+    const labelIdx = args.indexOf("--label");
+    expect(labelIdx).toBeGreaterThan(-1);
+    expect(args[labelIdx + 1]).toBe("bounty");
   });
 
   it("adds --language when languages configured", () => {
     const config = { ...defaultConfig, languages: ["typescript"] };
-    const args = buildGlobalSearchArgs(config);
+    const args = buildGlobalSearchArgs(config, "bounty");
     expect(args).toContain("--language");
     expect(args).toContain("typescript");
   });
 
+  it("only uses first language when multiple configured", () => {
+    const config = { ...defaultConfig, languages: ["typescript", "python", "go"] };
+    const args = buildGlobalSearchArgs(config, "bounty");
+    const languageFlags = args.reduce((count, arg) => arg === "--language" ? count + 1 : count, 0);
+    expect(languageFlags).toBe(1);
+    expect(args).toContain("typescript");
+    expect(args).not.toContain("python");
+    expect(args).not.toContain("go");
+  });
+
   it("does not add --language when languages empty", () => {
-    const args = buildGlobalSearchArgs(defaultConfig);
+    const args = buildGlobalSearchArgs(defaultConfig, "bounty");
     expect(args).not.toContain("--language");
   });
 
   it("uses max_results for --limit value", () => {
     const config = { ...defaultConfig, max_results: 25 };
-    const args = buildGlobalSearchArgs(config);
+    const args = buildGlobalSearchArgs(config, "bounty");
     const limitIdx = args.indexOf("--limit");
     expect(args[limitIdx + 1]).toBe("25");
   });
 
   it("includes repository in --json fields", () => {
-    const args = buildGlobalSearchArgs(defaultConfig);
+    const args = buildGlobalSearchArgs(defaultConfig, "bounty");
     const jsonIdx = args.indexOf("--json");
     expect(args[jsonIdx + 1]).toContain("repository");
   });
@@ -86,6 +94,11 @@ describe("parseGlobalSearchResults", () => {
     expect(issues[0].created_at).toBe("2026-02-15T00:00:00Z");
   });
 
+  it("returns empty array for empty results", () => {
+    const issues = parseGlobalSearchResults("[]", defaultConfig);
+    expect(issues).toEqual([]);
+  });
+
   it("filters by min_stars", () => {
     const config = { ...defaultConfig, min_stars: 50 };
     const raw = mockSearchResult({ repository: { nameWithOwner: "small/repo", stargazerCount: 10 } });
@@ -96,6 +109,13 @@ describe("parseGlobalSearchResults", () => {
   it("filters by keywords_exclude in title", () => {
     const config = { ...defaultConfig, keywords_exclude: ["internal"] };
     const raw = mockSearchResult({ title: "Internal tool fix $100" });
+    const issues = parseGlobalSearchResults(raw, config);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("filters by keywords_exclude in body", () => {
+    const config = { ...defaultConfig, keywords_exclude: ["confidential"] };
+    const raw = mockSearchResult({ title: "Fix bug $100", body: "This is a confidential project" });
     const issues = parseGlobalSearchResults(raw, config);
     expect(issues).toHaveLength(0);
   });
@@ -124,6 +144,19 @@ describe("parseGlobalSearchResults", () => {
     const raw = mockSearchResult({ title: "Fix the bug", body: "Reward: $250" });
     const issues = parseGlobalSearchResults(raw, defaultConfig);
     expect(issues[0].bounty_amount).toBe(250);
+  });
+
+  it("bounty_formatted falls back to body extraction", () => {
+    const raw = mockSearchResult({ title: "Fix the bug", body: "Reward: $250" });
+    const issues = parseGlobalSearchResults(raw, defaultConfig);
+    expect(issues[0].bounty_formatted).toBe("$250");
+  });
+
+  it("extracts comma-formatted bounty amounts", () => {
+    const raw = mockSearchResult({ title: "$1,000 bounty" });
+    const issues = parseGlobalSearchResults(raw, defaultConfig);
+    expect(issues[0].bounty_amount).toBe(1000);
+    expect(issues[0].bounty_formatted).toBe("$1,000");
   });
 
   it("keeps items that pass all filters", () => {

--- a/src/github-search.test.ts
+++ b/src/github-search.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { buildGlobalSearchArgs, parseGlobalSearchResults } from "./github-search.js";
+import type { GitHubSearchSource } from "./types.js";
+
+const defaultConfig: GitHubSearchSource = {
+  enabled: true,
+  labels: ["bounty"],
+  languages: [],
+  min_stars: 0,
+  keywords_exclude: [],
+  max_results: 50,
+};
+
+function mockSearchResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return JSON.stringify([{
+    number: 42,
+    title: "Fix the bug $100",
+    url: "https://github.com/org/repo/issues/42",
+    createdAt: "2026-02-15T00:00:00Z",
+    labels: [{ name: "bounty" }],
+    assignees: [],
+    body: "Bug description",
+    commentsCount: 2,
+    repository: { nameWithOwner: "org/repo", stargazerCount: 500 },
+    ...overrides,
+  }]);
+}
+
+describe("buildGlobalSearchArgs", () => {
+  it("builds correct base flags", () => {
+    const args = buildGlobalSearchArgs(defaultConfig);
+    expect(args).toContain("search");
+    expect(args).toContain("issues");
+    expect(args).toContain("--state");
+    expect(args).toContain("open");
+    expect(args).toContain("--limit");
+  });
+
+  it("adds individual --label flags for multiple labels", () => {
+    const config = { ...defaultConfig, labels: ["bounty", "\u{1F4B0} bounty"] };
+    const args = buildGlobalSearchArgs(config);
+    const labelFlags = args.reduce((count, arg) => arg === "--label" ? count + 1 : count, 0);
+    expect(labelFlags).toBe(2);
+    expect(args).toContain("bounty");
+    expect(args).toContain("\u{1F4B0} bounty");
+  });
+
+  it("adds --language when languages configured", () => {
+    const config = { ...defaultConfig, languages: ["typescript"] };
+    const args = buildGlobalSearchArgs(config);
+    expect(args).toContain("--language");
+    expect(args).toContain("typescript");
+  });
+
+  it("does not add --language when languages empty", () => {
+    const args = buildGlobalSearchArgs(defaultConfig);
+    expect(args).not.toContain("--language");
+  });
+
+  it("uses max_results for --limit value", () => {
+    const config = { ...defaultConfig, max_results: 25 };
+    const args = buildGlobalSearchArgs(config);
+    const limitIdx = args.indexOf("--limit");
+    expect(args[limitIdx + 1]).toBe("25");
+  });
+
+  it("includes repository in --json fields", () => {
+    const args = buildGlobalSearchArgs(defaultConfig);
+    const jsonIdx = args.indexOf("--json");
+    expect(args[jsonIdx + 1]).toContain("repository");
+  });
+});
+
+describe("parseGlobalSearchResults", () => {
+  it("maps results to BountyIssue with github_search source", () => {
+    const issues = parseGlobalSearchResults(mockSearchResult(), defaultConfig);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].source).toBe("github_search");
+    expect(issues[0].repo).toBe("org/repo");
+    expect(issues[0].number).toBe(42);
+    expect(issues[0].title).toBe("Fix the bug $100");
+    expect(issues[0].url).toBe("https://github.com/org/repo/issues/42");
+    expect(issues[0].labels).toEqual(["bounty"]);
+    expect(issues[0].body).toBe("Bug description");
+    expect(issues[0].comment_count).toBe(2);
+    expect(issues[0].created_at).toBe("2026-02-15T00:00:00Z");
+  });
+
+  it("filters by min_stars", () => {
+    const config = { ...defaultConfig, min_stars: 50 };
+    const raw = mockSearchResult({ repository: { nameWithOwner: "small/repo", stargazerCount: 10 } });
+    const issues = parseGlobalSearchResults(raw, config);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("filters by keywords_exclude in title", () => {
+    const config = { ...defaultConfig, keywords_exclude: ["internal"] };
+    const raw = mockSearchResult({ title: "Internal tool fix $100" });
+    const issues = parseGlobalSearchResults(raw, config);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("filters by keywords_exclude case-insensitively", () => {
+    const config = { ...defaultConfig, keywords_exclude: ["INTERNAL"] };
+    const raw = mockSearchResult({ title: "Fix internal bug $100" });
+    const issues = parseGlobalSearchResults(raw, config);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("deduplicates against watched repos", () => {
+    const raw = mockSearchResult({ repository: { nameWithOwner: "Expensify/App", stargazerCount: 500 } });
+    const issues = parseGlobalSearchResults(raw, defaultConfig, ["Expensify/App"]);
+    expect(issues).toHaveLength(0);
+  });
+
+  it("extracts bounty amount from title", () => {
+    const raw = mockSearchResult({ title: "$500 bounty for fix" });
+    const issues = parseGlobalSearchResults(raw, defaultConfig);
+    expect(issues[0].bounty_amount).toBe(500);
+    expect(issues[0].bounty_formatted).toBe("$500");
+  });
+
+  it("extracts bounty amount from body when not in title", () => {
+    const raw = mockSearchResult({ title: "Fix the bug", body: "Reward: $250" });
+    const issues = parseGlobalSearchResults(raw, defaultConfig);
+    expect(issues[0].bounty_amount).toBe(250);
+  });
+
+  it("keeps items that pass all filters", () => {
+    const config = { ...defaultConfig, min_stars: 100, keywords_exclude: ["spam"] };
+    const raw = mockSearchResult();
+    const issues = parseGlobalSearchResults(raw, config, ["other/repo"]);
+    expect(issues).toHaveLength(1);
+  });
+});

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from "node:child_process";
+import type { BountyIssue, GitHubSearchSource } from "./types.js";
+
+interface GHSearchResult {
+  number: number;
+  title: string;
+  url: string;
+  createdAt: string;
+  labels: Array<{ name: string }>;
+  assignees: Array<{ login: string }>;
+  body: string;
+  commentsCount: number;
+  repository: { nameWithOwner: string; stargazerCount: number };
+}
+
+function extractBountyAmount(text: string): number | undefined {
+  const match = text.match(/\$(\d[\d,]*)/);
+  if (!match) return undefined;
+  return parseInt(match[1].replace(/,/g, ""), 10);
+}
+
+function extractBountyFormatted(text: string): string | undefined {
+  const match = text.match(/(\$\d[\d,]*)/);
+  return match?.[1];
+}
+
+export function buildGlobalSearchArgs(config: GitHubSearchSource): string[] {
+  const args = [
+    "search", "issues",
+    "--state", "open",
+    "--sort", "created",
+    "--order", "desc",
+    "--limit", String(config.max_results),
+    "--json", "number,title,url,createdAt,labels,body,commentsCount,assignees,repository",
+  ];
+  for (const label of config.labels) {
+    args.push("--label", label);
+  }
+  for (const language of config.languages) {
+    args.push("--language", language);
+  }
+  return args;
+}
+
+export function parseGlobalSearchResults(
+  raw: string,
+  config: GitHubSearchSource,
+  watchedRepos?: string[],
+): BountyIssue[] {
+  const results = JSON.parse(raw) as GHSearchResult[];
+
+  return results
+    .filter((item) => {
+      if (config.min_stars > 0 && item.repository.stargazerCount < config.min_stars) {
+        return false;
+      }
+      if (watchedRepos?.includes(item.repository.nameWithOwner)) {
+        return false;
+      }
+      if (config.keywords_exclude.length > 0) {
+        const text = (item.title + " " + item.body).toLowerCase();
+        if (config.keywords_exclude.some((kw) => text.includes(kw.toLowerCase()))) {
+          return false;
+        }
+      }
+      return true;
+    })
+    .map((item) => ({
+      source: "github_search" as const,
+      repo: item.repository.nameWithOwner,
+      number: item.number,
+      title: item.title,
+      url: item.url,
+      labels: item.labels.map((l) => l.name),
+      assignees: item.assignees.map((a) => a.login),
+      body: item.body,
+      comment_count: item.commentsCount,
+      created_at: item.createdAt,
+      bounty_amount: extractBountyAmount(item.title + " " + item.body),
+      bounty_formatted: extractBountyFormatted(item.title),
+    }));
+}
+
+export function fetchGlobalBounties(
+  config: GitHubSearchSource,
+  watchedRepos?: string[],
+): BountyIssue[] {
+  const args = buildGlobalSearchArgs(config);
+  const raw = execFileSync("gh", args, { encoding: "utf-8", timeout: 30000 });
+  return parseGlobalSearchResults(raw, config, watchedRepos);
+}

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -24,7 +24,7 @@ function extractBountyFormatted(text: string): string | undefined {
   return match?.[1];
 }
 
-export function buildGlobalSearchArgs(config: GitHubSearchSource): string[] {
+export function buildGlobalSearchArgs(config: GitHubSearchSource, label: string): string[] {
   const args = [
     "search", "issues",
     "--state", "open",
@@ -32,12 +32,11 @@ export function buildGlobalSearchArgs(config: GitHubSearchSource): string[] {
     "--order", "desc",
     "--limit", String(config.max_results),
     "--json", "number,title,url,createdAt,labels,body,commentsCount,assignees,repository",
+    "--label", label,
   ];
-  for (const label of config.labels) {
-    args.push("--label", label);
-  }
-  for (const language of config.languages) {
-    args.push("--language", language);
+  // gh only supports one --language flag; use first configured language
+  if (config.languages.length > 0) {
+    args.push("--language", config.languages[0]);
   }
   return args;
 }
@@ -77,7 +76,7 @@ export function parseGlobalSearchResults(
       comment_count: item.commentsCount,
       created_at: item.createdAt,
       bounty_amount: extractBountyAmount(item.title + " " + item.body),
-      bounty_formatted: extractBountyFormatted(item.title),
+      bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
     }));
 }
 
@@ -85,7 +84,38 @@ export function fetchGlobalBounties(
   config: GitHubSearchSource,
   watchedRepos?: string[],
 ): BountyIssue[] {
-  const args = buildGlobalSearchArgs(config);
-  const raw = execFileSync("gh", args, { encoding: "utf-8", timeout: 30000 });
-  return parseGlobalSearchResults(raw, config, watchedRepos);
+  const seenUrls = new Set<string>();
+  const allBounties: BountyIssue[] = [];
+
+  let failedLabels = 0;
+
+  for (const label of config.labels) {
+    const args = buildGlobalSearchArgs(config, label);
+    let raw: string;
+    try {
+      raw = execFileSync("gh", args, { encoding: "utf-8", timeout: 30000 });
+    } catch (err) {
+      failedLabels++;
+      console.error(
+        `  GitHub Search: failed to fetch label "${label}":`,
+        err instanceof Error ? err.message : err
+      );
+      continue;
+    }
+    const bounties = parseGlobalSearchResults(raw, config, watchedRepos);
+    for (const bounty of bounties) {
+      if (!seenUrls.has(bounty.url)) {
+        seenUrls.add(bounty.url);
+        allBounties.push(bounty);
+      }
+    }
+  }
+
+  if (failedLabels === config.labels.length && config.labels.length > 0) {
+    throw new Error(
+      `GitHub Global Search: all ${failedLabels} label searches failed. Check that 'gh' is installed and authenticated (gh auth status).`
+    );
+  }
+
+  return allBounties;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,20 +65,24 @@ async function main() {
       }
 
       if (config.sources.algora?.enabled) {
-        const bounties = await fetchAlgoraBounties(buildAlgoraFilters(config.sources.algora));
-        for (const issue of bounties) {
-          if (!applyFreshnessFilter(issue, config.filters)) continue;
+        try {
+          const bounties = await fetchAlgoraBounties(buildAlgoraFilters(config.sources.algora));
+          for (const issue of bounties) {
+            if (!applyFreshnessFilter(issue, config.filters)) continue;
 
-          let vetResult: VetResult | undefined;
-          if (vettingEnabled) {
-            vetResult = vetIssue(issue, [], config.vetting);
+            let vetResult: VetResult | undefined;
+            if (vettingEnabled) {
+              vetResult = vetIssue(issue, [], config.vetting);
+            }
+
+            allIssues.push({
+              ...issue,
+              is_new: !seen.hasSeen(issue.repo, issue.number),
+              ...(vetResult ? { vetResult } : {}),
+            });
           }
-
-          allIssues.push({
-            ...issue,
-            is_new: !seen.hasSeen(issue.repo, issue.number),
-            ...(vetResult ? { vetResult } : {}),
-          });
+        } catch (err) {
+          console.error("Error fetching Algora bounties:", err instanceof Error ? err.message : err);
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
 import { fetchRepoIssues, fetchIssueComments } from "./github.js";
 import { fetchAlgoraBounties, buildAlgoraFilters } from "./algora.js";
+import { fetchGlobalBounties } from "./github-search.js";
 import { SeenStore } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
 import { applyPreFilter, applyFreshnessFilter } from "./monitor.js";
@@ -78,6 +79,38 @@ async function main() {
             is_new: !seen.hasSeen(issue.repo, issue.number),
             ...(vetResult ? { vetResult } : {}),
           });
+        }
+      }
+
+      // Poll GitHub Global Search
+      if (config.sources.github_search?.enabled) {
+        try {
+          const watchedRepos = config.sources.repos.map((r) => r.name);
+          const bounties = fetchGlobalBounties(config.sources.github_search, watchedRepos);
+          for (const issue of bounties) {
+            if (!applyFreshnessFilter(issue, config.filters)) continue;
+
+            let vetResult: VetResult | undefined;
+            if (vettingEnabled) {
+              try {
+                const comments = fetchIssueComments(issue.repo, issue.number);
+                vetResult = vetIssue(issue, comments, config.vetting);
+              } catch (err) {
+                console.error(
+                  `  Vetting error for ${issue.repo}#${issue.number}:`,
+                  err instanceof Error ? err.message : err
+                );
+              }
+            }
+
+            allIssues.push({
+              ...issue,
+              is_new: !seen.hasSeen(issue.repo, issue.number),
+              ...(vetResult ? { vetResult } : {}),
+            });
+          }
+        } catch (err) {
+          console.error("Error fetching GitHub Global Search:", err instanceof Error ? err.message : err);
         }
       }
 

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -145,6 +145,32 @@ describe("applyFreshnessFilter", () => {
       expect(applyFreshnessFilter(issue, { ...defaultFilters, max_comment_count: 0 })).toBe(true);
     });
   });
+
+  describe("github_search filtering", () => {
+    it("rejects github_search issues with assignees when skip_assigned is true", () => {
+      vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
+      const issue = makeIssue({ source: "github_search", assignees: ["someone"] });
+      expect(applyFreshnessFilter(issue, { ...defaultFilters, skip_assigned: true })).toBe(false);
+    });
+
+    it("rejects github_search issues with claimed labels", () => {
+      vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
+      const issue = makeIssue({ source: "github_search", labels: ["Reviewing"] });
+      expect(applyFreshnessFilter(issue, { ...defaultFilters, claimed_labels: ["Reviewing"] })).toBe(false);
+    });
+
+    it("rejects github_search issues exceeding comment count", () => {
+      vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
+      const issue = makeIssue({ source: "github_search", comment_count: 10 });
+      expect(applyFreshnessFilter(issue, { ...defaultFilters, max_comment_count: 5 })).toBe(false);
+    });
+
+    it("passes github_search issues that meet all criteria", () => {
+      vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
+      const issue = makeIssue({ source: "github_search", assignees: [], labels: ["bounty"], comment_count: 1 });
+      expect(applyFreshnessFilter(issue, defaultFilters)).toBe(true);
+    });
+  });
 });
 
 describe("shouldNotify", () => {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -3,6 +3,7 @@ import { resolve, join } from "node:path";
 import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
 import { fetchRepoIssues, fetchIssueComments } from "./github.js";
 import { fetchAlgoraBounties, buildAlgoraFilters } from "./algora.js";
+import { fetchGlobalBounties } from "./github-search.js";
 import { SeenStore } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
 import { vetIssue } from "./vet.js";
@@ -31,7 +32,7 @@ export function applyFreshnessFilter(issue: BountyIssue, filters: Filters): bool
   // GitHub-specific checks — Algora handles claiming at the API level and
   // hardcodes assignees/labels/comment_count to empty/zero, so these only
   // provide useful signal for GitHub issues.
-  if (issue.source === "github") {
+  if (issue.source === "github" || issue.source === "github_search") {
     if (filters.skip_assigned && issue.assignees.length > 0) return false;
 
     if (filters.claimed_labels.length > 0) {
@@ -135,6 +136,37 @@ export async function runMonitor(): Promise<void> {
       }
     } catch (err) {
       console.error("Error polling Algora:", err);
+    }
+  }
+
+  // Poll GitHub Global Search
+  if (config.sources.github_search?.enabled) {
+    try {
+      const watchedRepos = config.sources.repos.map((r) => r.name);
+      const bounties = fetchGlobalBounties(config.sources.github_search, watchedRepos);
+      for (const issue of bounties) {
+        if (seen.hasSeen(issue.repo, issue.number)) continue;
+        if (!applyFreshnessFilter(issue, config.filters)) continue;
+
+        seen.markSeenFromBounty(issue);
+
+        let vetResult: VetResult | undefined;
+        if (vettingEnabled) {
+          try {
+            const comments = fetchIssueComments(issue.repo, issue.number);
+            vetResult = vetIssue(issue, comments, config.vetting);
+          } catch (err) {
+            console.error(
+              `  Vetting error for ${issue.repo}#${issue.number}:`,
+              err
+            );
+          }
+        }
+
+        allNew.push({ issue, vetResult });
+      }
+    } catch (err) {
+      console.error("Error polling GitHub Global Search:", err);
     }
   }
 

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -91,4 +91,21 @@ describe("formatBountyNotification", () => {
     expect(msg).toContain("Proposals: 2");
     expect(msg).not.toContain("Proposals: 15");
   });
+
+  it("shows (Global) for github_search issues", () => {
+    const issue = makeIssue({
+      source: "github_search",
+      repo: "some-org/some-repo",
+      number: 42,
+      title: "Fix something",
+      url: "https://github.com/some-org/some-repo/issues/42",
+      bounty_amount: 500,
+      bounty_formatted: "$500",
+      labels: ["bounty"],
+      body: "",
+      comment_count: 0,
+    });
+    const result = formatBountyNotification(issue);
+    expect(result).toContain("(Global)");
+  });
 });

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -6,7 +6,7 @@ export function formatBountyNotification(
   issue: BountyIssue,
   vetResult?: VetResult
 ): string {
-  const source = issue.source === "algora" ? " (Algora)" : "";
+  const source = issue.source === "algora" ? " (Algora)" : issue.source === "github_search" ? " (Global)" : "";
   const bounty = issue.bounty_formatted ? ` — ${issue.bounty_formatted}` : "";
   const labels = issue.labels.length
     ? `\nLabels: ${issue.labels.join(", ")}`

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,16 @@ const AlgoraSourceSchema = z.object({
   min_bounty: z.number(),
   languages: z.array(z.string()),
   keywords_exclude: z.array(z.string()),
+  max_pages: z.number().default(3),
+});
+
+export const GitHubSearchSourceSchema = z.object({
+  enabled: z.boolean().default(false),
+  labels: z.array(z.string()).default(["bounty"]),
+  languages: z.array(z.string()).default([]),
+  min_stars: z.number().default(0),
+  keywords_exclude: z.array(z.string()).default([]),
+  max_results: z.number().default(50),
 });
 
 const TelegramConfigSchema = z.object({
@@ -95,6 +105,7 @@ export const WatchlistConfigSchema = z.object({
   sources: z.object({
     repos: z.array(RepoSourceSchema),
     algora: AlgoraSourceSchema,
+    github_search: GitHubSearchSourceSchema.optional(),
   }),
   filters: FiltersObjectSchema.optional().default({
     ...FILTER_DEFAULTS,
@@ -115,6 +126,7 @@ export const WatchlistConfigSchema = z.object({
 // Derive types from schemas
 export type RepoSource = z.infer<typeof RepoSourceSchema>;
 export type AlgoraSource = z.infer<typeof AlgoraSourceSchema>;
+export type GitHubSearchSource = z.infer<typeof GitHubSearchSourceSchema>;
 export type TelegramConfig = z.infer<typeof TelegramConfigSchema>;
 export type Filters = z.infer<typeof FiltersSchema>;
 export type VettingConfig = z.infer<typeof VettingConfigSchema>;
@@ -131,8 +143,10 @@ export interface SeenIssue {
   skipped: boolean;
 }
 
+export type BountySourceType = "github" | "algora" | "github_search";
+
 export interface BountyIssue {
-  source: "github" | "algora";
+  source: BountySourceType;
   repo: string;
   number: number;
   title: string;

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -65,3 +65,18 @@ sources:
     min_bounty: 50
     languages: []
     keywords_exclude: []
+
+  # GitHub Global Label Search — searches ALL of GitHub for bounty-labeled issues
+  # This discovers bounties beyond your watched repos
+  github_search:
+    enabled: false             # Set to true to enable global search
+    labels:                    # GitHub labels to search for
+      - "bounty"
+      - "💰 bounty"
+    languages:                 # Filter by repo language (empty = all languages)
+      - typescript
+      - python
+      - go
+    min_stars: 50              # Only include repos with >= N stars (0 = disabled)
+    keywords_exclude: []       # Skip issues containing these keywords
+    max_results: 50            # Max results per search


### PR DESCRIPTION
## Summary

Implements #8 — expands bounty-hunter beyond its current 2 sources to discover bounties across a much wider surface.

- **GitHub Global Label Search** — searches ALL of GitHub for bounty-labeled issues (`label:bounty`, `label:💰 bounty`, etc.) rather than only watching manually-configured repos. Configurable by labels, languages, min_stars, and keywords_exclude
- **Algora cursor-based pagination** — follows `next_cursor` tokens to fetch up to 150 bounties (3 pages x 50) instead of just 50
- **Formalized source types** — `BountySourceType` union and `GitHubSearchSourceSchema` make adding future sources straightforward

### Files changed

| File | Change |
|---|---|
| `src/types.ts` | Added `BountySourceType`, `GitHubSearchSourceSchema`, `max_pages` on Algora |
| `src/github-search.ts` | **New** — GitHub Global Search via `gh search issues` |
| `src/github-search.test.ts` | **New** — 14 tests |
| `src/algora.ts` | Cursor-based pagination loop |
| `src/algora.test.ts` | +3 pagination tests |
| `src/monitor.ts` | Wired github_search into polling + freshness filter |
| `src/index.ts` | Wired github_search into scan command |
| `src/telegram.ts` | Shows "(Global)" tag for github_search issues |
| `watchlist.example.yml` | Added github_search config section |

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npx vitest run` — 136 unit tests pass (up from 109)
- [ ] `bounty-hunter scan --json` — shows results from all 3 sources
- [ ] Enable `github_search` in `watchlist.yml`, verify it discovers bounties beyond watched repos
- [ ] Verify Algora pagination fetches more than 50 items when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)