### PR TITLE
Add cross-source dedup and Boss.dev GitHub enrichment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,13 +109,14 @@ templates/
 3. `monitor.ts` vets survivors: `fetchIssueComments()` → `vetIssue()` → `shouldNotify()`
 4. `monitor.ts` polls Algora: `fetchAlgoraBounties(buildAlgoraFilters())` → freshness → vet (body-only, no comments)
 4.5. `monitor.ts` polls GitHub Global Search: `fetchGlobalBounties()` → dedup watched repos → `applyFreshnessFilter()` → `fetchIssueComments()` → `vetIssue()` → `shouldNotify()`
-4.6. `monitor.ts` polls Boss.dev: `fetchBossBounties(buildBossFilters())` → freshness → vet (body-only, no comments)
+4.6. `monitor.ts` polls Boss.dev: `fetchBossBounties(buildBossFilters())` → `fetchIssueMetadata()` (enrich) → freshness → `fetchIssueComments()` → `vetIssue()`
+4.7. `index.ts` scan uses in-memory `Set<string>` for cross-source dedup within a single run
 5. New issues → `formatBountyNotification(issue, vetResult?)` → `sendTelegramMessage()`
 
 ## Testing
 
 - Tests live alongside source as `*.test.ts`
-- 140+ tests across 9 files
+- 174+ tests across 10 files
 - Integration test (`integration.test.ts`) hits real GitHub API via `gh` — requires `gh auth status`
 - Integration test overrides `HOME` to isolate config; preserves `GH_CONFIG_DIR` for auth
 - Run: `npx vitest run` (all tests) or `npx vitest run src/github.test.ts` (single file)

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -162,4 +162,24 @@ describe("fetchIssueMetadata", () => {
 
     mockExecFileSync.mockReset();
   });
+
+  it("throws when gh CLI fails", async () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("gh: command not found");
+    });
+
+    const { fetchIssueMetadata } = await import("./github.js");
+    expect(() => fetchIssueMetadata("foo/bar", 1)).toThrow("gh: command not found");
+
+    mockExecFileSync.mockReset();
+  });
+
+  it("throws on malformed JSON from gh", async () => {
+    mockExecFileSync.mockReturnValue("not valid json");
+
+    const { fetchIssueMetadata } = await import("./github.js");
+    expect(() => fetchIssueMetadata("foo/bar", 1)).toThrow();
+
+    mockExecFileSync.mockReset();
+  });
 });

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import { parseIssueUrl, buildSearchArgs, buildIssueViewArgs } from "./github.js";
+import { describe, it, expect, vi } from "vitest";
+import { parseIssueUrl, buildSearchArgs, buildIssueViewArgs, buildIssueMetadataArgs } from "./github.js";
+
+const mockExecFileSync = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}));
 
 describe("parseIssueUrl", () => {
   it("parses a standard GitHub issue URL", () => {
@@ -64,5 +69,97 @@ describe("buildIssueViewArgs", () => {
   it("passes issue number as string", () => {
     const args = buildIssueViewArgs("foo/bar", 42);
     expect(args).toContain("42");
+  });
+});
+
+describe("buildIssueMetadataArgs", () => {
+  it("builds gh issue view args for fetching metadata", () => {
+    const args = buildIssueMetadataArgs("Expensify/App", 81500);
+    expect(args).toContain("issue");
+    expect(args).toContain("view");
+    expect(args).toContain("81500");
+    expect(args).toContain("Expensify/App");
+  });
+
+  it("requests the correct JSON fields", () => {
+    const args = buildIssueMetadataArgs("Expensify/App", 81500);
+    const jsonIdx = args.indexOf("--json");
+    expect(jsonIdx).toBeGreaterThan(-1);
+    const jsonFields = args[jsonIdx + 1];
+    expect(jsonFields).toContain("body");
+    expect(jsonFields).toContain("labels");
+    expect(jsonFields).toContain("assignees");
+    expect(jsonFields).toContain("createdAt");
+    expect(jsonFields).toContain("commentsCount");
+  });
+
+  it("uses --repo flag for the repo", () => {
+    const args = buildIssueMetadataArgs("foo/bar", 42);
+    const repoIdx = args.indexOf("--repo");
+    expect(repoIdx).toBeGreaterThan(-1);
+    expect(args[repoIdx + 1]).toBe("foo/bar");
+  });
+
+  it("passes issue number as string", () => {
+    const args = buildIssueMetadataArgs("foo/bar", 42);
+    expect(args).toContain("42");
+  });
+});
+
+describe("fetchIssueMetadata", () => {
+  it("parses GitHub API response into IssueMetadata", async () => {
+    const mockResponse = JSON.stringify({
+      body: "Fix the login bug",
+      labels: [{ name: "bug" }, { name: "Help Wanted" }],
+      assignees: [{ login: "alice" }, { login: "bob" }],
+      createdAt: "2025-01-15T10:00:00Z",
+      commentsCount: 5,
+    });
+
+    mockExecFileSync.mockReturnValue(mockResponse);
+
+    const { fetchIssueMetadata } = await import("./github.js");
+    const result = fetchIssueMetadata("Expensify/App", 81500);
+
+    expect(result).toEqual({
+      body: "Fix the login bug",
+      labels: ["bug", "Help Wanted"],
+      assignees: ["alice", "bob"],
+      comment_count: 5,
+      created_at: "2025-01-15T10:00:00Z",
+    });
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      buildIssueMetadataArgs("Expensify/App", 81500),
+      expect.objectContaining({ encoding: "utf-8", timeout: 15000 }),
+    );
+
+    mockExecFileSync.mockReset();
+  });
+
+  it("handles empty labels and assignees", async () => {
+    const mockResponse = JSON.stringify({
+      body: "",
+      labels: [],
+      assignees: [],
+      createdAt: "2025-06-01T00:00:00Z",
+      commentsCount: 0,
+    });
+
+    mockExecFileSync.mockReturnValue(mockResponse);
+
+    const { fetchIssueMetadata } = await import("./github.js");
+    const result = fetchIssueMetadata("foo/bar", 1);
+
+    expect(result).toEqual({
+      body: "",
+      labels: [],
+      assignees: [],
+      comment_count: 0,
+      created_at: "2025-06-01T00:00:00Z",
+    });
+
+    mockExecFileSync.mockReset();
   });
 });

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,6 +1,14 @@
 import { execFileSync } from "node:child_process";
 import type { BountyIssue, GitHubAuthorAssociation, IssueComment } from "./types.js";
 
+export interface IssueMetadata {
+  body: string;
+  labels: string[];
+  assignees: string[];
+  comment_count: number;
+  created_at: string;
+}
+
 interface ParsedIssueUrl {
   owner: string;
   repo: string;
@@ -95,6 +103,40 @@ export function fetchIssueComments(
     createdAt: c.createdAt,
     url: c.url,
   }));
+}
+
+export function buildIssueMetadataArgs(repo: string, number: number): string[] {
+  return [
+    "issue",
+    "view",
+    String(number),
+    "--repo",
+    repo,
+    "--json",
+    "body,labels,assignees,createdAt,commentsCount",
+  ];
+}
+
+export function fetchIssueMetadata(
+  repo: string,
+  number: number
+): IssueMetadata {
+  const args = buildIssueMetadataArgs(repo, number);
+  const raw = execFileSync("gh", args, { encoding: "utf-8", timeout: 15000 });
+  const data = JSON.parse(raw) as {
+    body: string;
+    labels: Array<{ name: string }>;
+    assignees: Array<{ login: string }>;
+    createdAt: string;
+    commentsCount: number;
+  };
+  return {
+    body: data.body,
+    labels: data.labels.map((l) => l.name),
+    assignees: data.assignees.map((a) => a.login),
+    comment_count: data.commentsCount,
+    created_at: data.createdAt,
+  };
 }
 
 function extractBountyAmount(text: string): number | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,10 @@ async function main() {
               issue.comment_count = meta.comment_count;
               issue.created_at = meta.created_at;
             } catch (err) {
-              console.warn(`Could not enrich ${issue.repo}#${issue.number}:`, err);
+              console.warn(
+                `Could not enrich ${issue.repo}#${issue.number} — filtering will use Boss.dev defaults (no age/label/assignee data):`,
+                err instanceof Error ? err.message : err
+              );
             }
 
             if (!applyFreshnessFilter(issue, config.filters)) continue;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
-import { fetchRepoIssues, fetchIssueComments } from "./github.js";
+import { fetchRepoIssues, fetchIssueComments, fetchIssueMetadata } from "./github.js";
 import { fetchAlgoraBounties, buildAlgoraFilters } from "./algora.js";
 import { fetchGlobalBounties } from "./github-search.js";
 import { fetchBossBounties, buildBossFilters } from "./boss.js";
@@ -31,6 +31,7 @@ async function main() {
       const seen = new SeenStore(join(dataDir, "seen.json"));
       const vettingEnabled = config.vetting.enabled;
       const allIssues: ScanResult[] = [];
+      const seenThisScan = new Set<string>();
 
       for (const repo of config.sources.repos) {
         let issues: BountyIssue[];
@@ -41,6 +42,9 @@ async function main() {
           continue;
         }
         for (const issue of issues) {
+          const issueKey = `${issue.repo}#${issue.number}`;
+          if (seenThisScan.has(issueKey)) continue;
+          seenThisScan.add(issueKey);
           if (!applyPreFilter(issue, repo.pre_filter)) continue;
           if (!applyFreshnessFilter(issue, config.filters)) continue;
 
@@ -69,6 +73,9 @@ async function main() {
         try {
           const bounties = await fetchAlgoraBounties(buildAlgoraFilters(config.sources.algora));
           for (const issue of bounties) {
+            const issueKey = `${issue.repo}#${issue.number}`;
+            if (seenThisScan.has(issueKey)) continue;
+            seenThisScan.add(issueKey);
             if (!applyFreshnessFilter(issue, config.filters)) continue;
 
             let vetResult: VetResult | undefined;
@@ -93,6 +100,9 @@ async function main() {
           const watchedRepos = config.sources.repos.map((r) => r.name);
           const bounties = fetchGlobalBounties(config.sources.github_search, watchedRepos);
           for (const issue of bounties) {
+            const issueKey = `${issue.repo}#${issue.number}`;
+            if (seenThisScan.has(issueKey)) continue;
+            seenThisScan.add(issueKey);
             if (!applyFreshnessFilter(issue, config.filters)) continue;
 
             let vetResult: VetResult | undefined;
@@ -120,17 +130,39 @@ async function main() {
       }
 
       // Poll Boss.dev
-      // Note: Boss API has no creation dates — max_age_days is effectively a no-op.
-      // Cross-source dedup handled by SeenStore (repo#number key).
       if (config.sources.boss?.enabled) {
         try {
           const bounties = await fetchBossBounties(buildBossFilters(config.sources.boss));
           for (const issue of bounties) {
+            const issueKey = `${issue.repo}#${issue.number}`;
+            if (seenThisScan.has(issueKey)) continue;
+            seenThisScan.add(issueKey);
+
+            // Enrich with GitHub metadata (real dates, labels, assignees, body)
+            try {
+              const meta = fetchIssueMetadata(issue.repo, issue.number);
+              issue.body = meta.body;
+              issue.labels = meta.labels;
+              issue.assignees = meta.assignees;
+              issue.comment_count = meta.comment_count;
+              issue.created_at = meta.created_at;
+            } catch (err) {
+              console.warn(`Could not enrich ${issue.repo}#${issue.number}:`, err);
+            }
+
             if (!applyFreshnessFilter(issue, config.filters)) continue;
 
             let vetResult: VetResult | undefined;
             if (vettingEnabled) {
-              vetResult = vetIssue(issue, [], config.vetting);
+              try {
+                const comments = fetchIssueComments(issue.repo, issue.number);
+                vetResult = vetIssue(issue, comments, config.vetting);
+              } catch (err) {
+                console.error(
+                  `  Vetting error for ${issue.repo}#${issue.number}:`,
+                  err instanceof Error ? err.message : err
+                );
+              }
             }
 
             allIssues.push({

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -173,15 +173,26 @@ describe("applyFreshnessFilter", () => {
   });
 
   describe("boss filtering", () => {
-    it("skips GitHub-specific checks for boss issues (assignees, labels, comments)", () => {
+    it("applies assignee/label/comment checks to enriched boss issues", () => {
       vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
-      const issue = makeIssue({
-        source: "boss",
-        assignees: ["someone"],
-        labels: ["Reviewing"],
-        comment_count: 100,
-      });
-      // Boss issues skip assignee, claimed-label, and comment-count checks
+      // Enriched Boss issues have real metadata — filters should apply
+      expect(applyFreshnessFilter(
+        makeIssue({ source: "boss", assignees: ["someone"] }),
+        { ...defaultFilters, skip_assigned: true }
+      )).toBe(false);
+      expect(applyFreshnessFilter(
+        makeIssue({ source: "boss", labels: ["Reviewing"] }),
+        defaultFilters
+      )).toBe(false);
+      expect(applyFreshnessFilter(
+        makeIssue({ source: "boss", comment_count: 10 }),
+        { ...defaultFilters, max_comment_count: 5 }
+      )).toBe(false);
+    });
+
+    it("passes boss issues that meet all criteria", () => {
+      vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
+      const issue = makeIssue({ source: "boss", assignees: [], labels: [], comment_count: 1 });
       expect(applyFreshnessFilter(issue, defaultFilters)).toBe(true);
     });
 

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import { resolve, join } from "node:path";
 import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
-import { fetchRepoIssues, fetchIssueComments } from "./github.js";
+import { fetchRepoIssues, fetchIssueComments, fetchIssueMetadata } from "./github.js";
 import { fetchAlgoraBounties, buildAlgoraFilters } from "./algora.js";
 import { fetchGlobalBounties } from "./github-search.js";
 import { fetchBossBounties, buildBossFilters } from "./boss.js";
@@ -172,20 +172,39 @@ export async function runMonitor(): Promise<void> {
   }
 
   // Poll Boss.dev
-  // Note: Boss API has no creation dates — created_at is set to fetch time,
-  // so max_age_days effectively only filters via SeenStore dedup, not issue age.
   if (config.sources.boss?.enabled) {
     try {
       const bounties = await fetchBossBounties(buildBossFilters(config.sources.boss));
       for (const issue of bounties) {
         if (seen.hasSeen(issue.repo, issue.number)) continue;
+
+        // Enrich with GitHub metadata (real dates, labels, assignees, body)
+        try {
+          const meta = fetchIssueMetadata(issue.repo, issue.number);
+          issue.body = meta.body;
+          issue.labels = meta.labels;
+          issue.assignees = meta.assignees;
+          issue.comment_count = meta.comment_count;
+          issue.created_at = meta.created_at;
+        } catch (err) {
+          console.warn(`Could not enrich ${issue.repo}#${issue.number}:`, err);
+        }
+
         if (!applyFreshnessFilter(issue, config.filters)) continue;
 
         seen.markSeenFromBounty(issue);
 
         let vetResult: VetResult | undefined;
         if (vettingEnabled) {
-          vetResult = vetIssue(issue, [], config.vetting);
+          try {
+            const comments = fetchIssueComments(issue.repo, issue.number);
+            vetResult = vetIssue(issue, comments, config.vetting);
+          } catch (err) {
+            console.error(
+              `  Vetting error for ${issue.repo}#${issue.number}:`,
+              err
+            );
+          }
         }
 
         allNew.push({ issue, vetResult });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -30,10 +30,10 @@ export function applyFreshnessFilter(issue: BountyIssue, filters: Filters): bool
     if (ageDays > filters.max_age_days) return false;
   }
 
-  // GitHub-specific checks — Algora handles claiming at the API level and
-  // hardcodes assignees/labels/comment_count to empty/zero, so these only
-  // provide useful signal for GitHub issues.
-  if (issue.source === "github" || issue.source === "github_search") {
+  // Algora handles claiming at the API level and hardcodes
+  // assignees/labels/comment_count to empty/zero, so skip these checks.
+  // Boss.dev issues are enriched with real GitHub metadata before filtering.
+  if (issue.source !== "algora") {
     if (filters.skip_assigned && issue.assignees.length > 0) return false;
 
     if (filters.claimed_labels.length > 0) {
@@ -187,7 +187,10 @@ export async function runMonitor(): Promise<void> {
           issue.comment_count = meta.comment_count;
           issue.created_at = meta.created_at;
         } catch (err) {
-          console.warn(`Could not enrich ${issue.repo}#${issue.number}:`, err);
+          console.warn(
+            `Could not enrich ${issue.repo}#${issue.number} — filtering will use Boss.dev defaults (no age/label/assignee data):`,
+            err instanceof Error ? err.message : err
+          );
         }
 
         if (!applyFreshnessFilter(issue, config.filters)) continue;


### PR DESCRIPTION
## Summary
- Add `fetchIssueMetadata()` to `github.ts` — fetches full issue data (body, labels, assignees, createdAt, commentsCount) via `gh issue view`
- Enrich Boss.dev issues with real GitHub metadata before filtering, enabling proper `max_age_days`, `skip_assigned`, `claimed_labels`, and `max_comment_count` checks that were previously blind
- Upgrade Boss.dev vetting from body-only to full vetting with comments
- Add in-memory `Set<string>` dedup in `index.ts` scan command to prevent duplicate output when the same issue appears from multiple sources (e.g., watched repo + Boss.dev)

## Test plan
- [x] 174 unit tests pass (10 test files)
- [x] 6 new tests for `fetchIssueMetadata` (args structure + response parsing)
- [x] TypeScript compiles cleanly
- [x] Pre-existing integration test failure is unrelated (GitHub API rate limit)

Closes #12, closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)