### PR TITLE
feat: add bounty confidence metadata for cross-source sorting

### DIFF
--- a/src/algora.ts
+++ b/src/algora.ts
@@ -94,6 +94,8 @@ function applyAlgoraFilters(items: AlgoraItem[], filters?: AlgoraFilterParams): 
       url: item.task.url,
       bounty_amount: item.reward.amount / 100,
       bounty_formatted: item.reward_formatted,
+      bounty_confidence: "api" as const,
+      bounty_currency: "USD" as const,
       labels: [],
       assignees: [],
       body: item.task.body,

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -53,6 +53,8 @@ export function parseBossResponse(
         url: item.url ?? "",
         bounty_amount: item.usd,
         bounty_formatted: `$${item.usd.toLocaleString("en-US")}`,
+        bounty_confidence: "api" as const,
+        bounty_currency: "USD" as const,
         labels: [],
         assignees: [],
         body: "",

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -77,6 +77,8 @@ export function parseGlobalSearchResults(
       created_at: item.createdAt,
       bounty_amount: extractBountyAmount(item.title + " " + item.body),
       bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
+      bounty_confidence: "text_extract" as const,
+      bounty_currency: "unknown" as const,
     }));
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -66,6 +66,8 @@ export function fetchRepoIssues(repo: string, labels: string[]): BountyIssue[] {
     created_at: issue.createdAt,
     bounty_amount: extractBountyAmount(issue.title + " " + issue.body),
     bounty_formatted: extractBountyFormatted(issue.title),
+    bounty_confidence: "text_extract" as const,
+    bounty_currency: "unknown" as const,
   }));
 }
 

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -7,7 +7,8 @@ export function formatBountyNotification(
   vetResult?: VetResult
 ): string {
   const source = issue.source === "algora" ? " (Algora)" : issue.source === "github_search" ? " (Global)" : issue.source === "boss" ? " (Boss)" : "";
-  const bounty = issue.bounty_formatted ? ` — ${issue.bounty_formatted}` : "";
+  const confidenceTag = issue.bounty_confidence === "text_extract" ? " ~" : "";
+  const bounty = issue.bounty_formatted ? ` — ${issue.bounty_formatted}${confidenceTag}` : "";
   const labels = issue.labels.length
     ? `\nLabels: ${issue.labels.join(", ")}`
     : "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -152,6 +152,9 @@ export interface SeenIssue {
 
 export type BountySourceType = "github" | "algora" | "github_search" | "boss";
 
+export type BountyConfidence = "api" | "text_extract";
+export type BountyCurrency = "USD" | "unknown";
+
 export interface BountyIssue {
   source: BountySourceType;
   repo: string;
@@ -160,6 +163,8 @@ export interface BountyIssue {
   url: string;
   bounty_amount?: number;
   bounty_formatted?: string;
+  bounty_confidence?: BountyConfidence;
+  bounty_currency?: BountyCurrency;
   labels: string[];
   assignees: string[];
   body: string;


### PR DESCRIPTION
## Summary
- Adds `bounty_confidence` (`"api"` | `"text_extract"`) and `bounty_currency` (`"USD"` | `"unknown"`) optional fields to `BountyIssue` interface
- Sets confidence to `"api"` / `"USD"` for Algora and Boss.dev sources (API-validated amounts)
- Sets confidence to `"text_extract"` / `"unknown"` for GitHub and GitHub Search sources (regex-extracted amounts)
- Adds `~` indicator in Telegram notifications for text-extracted bounty amounts

Closes #14

## Test plan
- [x] All 177 unit tests pass (integration test failure is pre-existing — missing build artifact)
- [ ] Verify Telegram notification shows `~` suffix for GitHub-sourced bounties
- [ ] Verify downstream consumers can filter/sort by `bounty_confidence`

🤖 Generated with [Claude Code](https://claude.com/claude-code)