### PR TITLE
feat: add bounty confidence metadata for cross-source sorting

### DIFF
--- a/src/algora.ts
+++ b/src/algora.ts
@@ -94,6 +94,8 @@ function applyAlgoraFilters(items: AlgoraItem[], filters?: AlgoraFilterParams): 
       url: item.task.url,
       bounty_amount: item.reward.amount / 100,
       bounty_formatted: item.reward_formatted,
+      bounty_confidence: "api" as const,
+      bounty_currency: item.reward.currency === "USD" ? "USD" : "unknown",
       labels: [],
       assignees: [],
       body: item.task.body,

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -53,6 +53,8 @@ export function parseBossResponse(
         url: item.url ?? "",
         bounty_amount: item.usd,
         bounty_formatted: `$${item.usd.toLocaleString("en-US")}`,
+        bounty_confidence: "api" as const,
+        bounty_currency: "USD" as const,
         labels: [],
         assignees: [],
         body: "",

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -77,6 +77,8 @@ export function parseGlobalSearchResults(
       created_at: item.createdAt,
       bounty_amount: extractBountyAmount(item.title + " " + item.body),
       bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
+      bounty_confidence: "text_extract" as const,
+      bounty_currency: "unknown" as const,
     }));
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -66,6 +66,8 @@ export function fetchRepoIssues(repo: string, labels: string[]): BountyIssue[] {
     created_at: issue.createdAt,
     bounty_amount: extractBountyAmount(issue.title + " " + issue.body),
     bounty_formatted: extractBountyFormatted(issue.title),
+    bounty_confidence: "text_extract" as const,
+    bounty_currency: "unknown" as const,
   }));
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,6 +160,8 @@ export interface BountyIssue {
   url: string;
   bounty_amount?: number;
   bounty_formatted?: string;
+  bounty_confidence?: "api" | "text_extract";
+  bounty_currency?: "USD" | "unknown";
   labels: string[];
   assignees: string[];
   body: string;


### PR DESCRIPTION
Implements Issue #14. Added `bounty_confidence` and `bounty_currency` metadata to `BountyIssue` type and populated it across Algora, Boss.dev, and GitHub sources. This enables downstream consumers to prioritize API-validated bounties over text-extracted ones.