### PR TITLE
Add bounty confidence metadata for cross-source sorting (#14)

### DIFF
--- a/src/algora.test.ts
+++ b/src/algora.test.ts
@@ -49,6 +49,8 @@ describe("parseAlgoraResponse", () => {
     expect(issues[0].bounty_amount).toBe(250);
     expect(issues[0].repo).toBe("test/repo");
     expect(issues[0].source).toBe("algora");
+    expect(issues[0].bounty_confidence).toBe("api");
+    expect(issues[0].bounty_currency).toBe("USD");
   });
 
   it("filters by minimum bounty", () => {

--- a/src/algora.ts
+++ b/src/algora.ts
@@ -94,6 +94,8 @@ function applyAlgoraFilters(items: AlgoraItem[], filters?: AlgoraFilterParams): 
       url: item.task.url,
       bounty_amount: item.reward.amount / 100,
       bounty_formatted: item.reward_formatted,
+      bounty_confidence: "api" as const,
+      bounty_currency: "USD" as const,
       labels: [],
       assignees: [],
       body: item.task.body,

--- a/src/boss.test.ts
+++ b/src/boss.test.ts
@@ -49,6 +49,8 @@ describe("parseBossResponse", () => {
     expect(issues[0].number).toBe(42);
     expect(issues[0].bounty_amount).toBe(500);
     expect(issues[0].url).toBe("https://github.com/org/repo/issues/42");
+    expect(issues[0].bounty_confidence).toBe("api");
+    expect(issues[0].bounty_currency).toBe("USD");
   });
 
   it("filters by minimum bounty", () => {

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -53,6 +53,8 @@ export function parseBossResponse(
         url: item.url ?? "",
         bounty_amount: item.usd,
         bounty_formatted: `$${item.usd.toLocaleString("en-US")}`,
+        bounty_confidence: "api" as const,
+        bounty_currency: "USD" as const,
         labels: [],
         assignees: [],
         body: "",

--- a/src/github-search.test.ts
+++ b/src/github-search.test.ts
@@ -80,7 +80,7 @@ describe("buildGlobalSearchArgs", () => {
 });
 
 describe("parseGlobalSearchResults", () => {
-  it("maps results to BountyIssue with github_search source", () => {
+  it("maps results to BountyIssue with github_search source and text_extract confidence", () => {
     const issues = parseGlobalSearchResults(mockSearchResult(), defaultConfig);
     expect(issues).toHaveLength(1);
     expect(issues[0].source).toBe("github_search");
@@ -92,6 +92,8 @@ describe("parseGlobalSearchResults", () => {
     expect(issues[0].body).toBe("Bug description");
     expect(issues[0].comment_count).toBe(2);
     expect(issues[0].created_at).toBe("2026-02-15T00:00:00Z");
+    expect(issues[0].bounty_confidence).toBe("text_extract");
+    expect(issues[0].bounty_currency).toBe("unknown");
   });
 
   it("returns empty array for empty results", () => {

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -77,6 +77,8 @@ export function parseGlobalSearchResults(
       created_at: item.createdAt,
       bounty_amount: extractBountyAmount(item.title + " " + item.body),
       bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
+      bounty_confidence: "text_extract" as const,
+      bounty_currency: "unknown" as const,
     }));
 }
 

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -183,3 +183,62 @@ describe("fetchIssueMetadata", () => {
     mockExecFileSync.mockReset();
   });
 });
+
+describe("fetchRepoIssues", () => {
+  it("maps issues with text_extract confidence metadata", async () => {
+    const mockResponse = JSON.stringify([
+      {
+        number: 1,
+        title: "Fix bug $500",
+        url: "https://github.com/foo/bar/issues/1",
+        createdAt: "2025-01-15T10:00:00Z",
+        labels: [{ name: "bug" }],
+        assignees: [{ login: "alice" }],
+        body: "Please fix this",
+        commentsCount: 3,
+      },
+    ]);
+
+    mockExecFileSync.mockReturnValue(mockResponse);
+
+    const { fetchRepoIssues } = await import("./github.js");
+    const issues = fetchRepoIssues("foo/bar", ["Help Wanted"]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].source).toBe("github");
+    expect(issues[0].bounty_confidence).toBe("text_extract");
+    expect(issues[0].bounty_currency).toBe("unknown");
+    expect(issues[0].bounty_amount).toBe(500);
+
+    mockExecFileSync.mockReset();
+  });
+
+  it("handles no bounty in title or body", async () => {
+    const mockResponse = JSON.stringify([
+      {
+        number: 1,
+        title: "Fix bug",
+        url: "https://github.com/foo/bar/issues/1",
+        createdAt: "2025-01-15T10:00:00Z",
+        labels: [],
+        assignees: [],
+        body: "No dollar amount here",
+        commentsCount: 0,
+      },
+    ]);
+
+    mockExecFileSync.mockReturnValue(mockResponse);
+
+    const { fetchRepoIssues } = await import("./github.js");
+    const issues = fetchRepoIssues("foo/bar", ["Help Wanted"]);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].bounty_amount).toBeUndefined();
+    expect(issues[0].bounty_formatted).toBeUndefined();
+    // Confidence metadata should still be present even without bounty amount
+    expect(issues[0].bounty_confidence).toBe("text_extract");
+    expect(issues[0].bounty_currency).toBe("unknown");
+
+    mockExecFileSync.mockReset();
+  });
+});

--- a/src/github.ts
+++ b/src/github.ts
@@ -66,6 +66,8 @@ export function fetchRepoIssues(repo: string, labels: string[]): BountyIssue[] {
     created_at: issue.createdAt,
     bounty_amount: extractBountyAmount(issue.title + " " + issue.body),
     bounty_formatted: extractBountyFormatted(issue.title),
+    bounty_confidence: "text_extract" as const,
+    bounty_currency: "unknown" as const,
   }));
 }
 

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -10,6 +10,8 @@ const makeIssue = (overrides: Partial<BountyIssue> = {}): BountyIssue => ({
   url: "https://github.com/Expensify/App/issues/81500",
   bounty_amount: 250,
   bounty_formatted: "$250",
+  bounty_confidence: "text_extract",
+  bounty_currency: "unknown",
   labels: ["Help Wanted", "Bug"],
   assignees: [],
   body: "Some description",
@@ -30,7 +32,7 @@ describe("formatBountyNotification", () => {
     expect(msg).toContain("\ud83c\udfaf");
   });
 
-  it("formats an Algora bounty issue", () => {
+  it("formats an Algora bounty issue with api confidence", () => {
     const issue = makeIssue({
       source: "algora",
       repo: "coolify/coolify",
@@ -39,6 +41,8 @@ describe("formatBountyNotification", () => {
       url: "https://github.com/coolify/coolify/issues/8154",
       bounty_amount: 6900,
       bounty_formatted: "$6,900",
+      bounty_confidence: "api",
+      bounty_currency: "USD",
       labels: [],
       body: "",
       comment_count: 0,
@@ -47,6 +51,7 @@ describe("formatBountyNotification", () => {
     const msg = formatBountyNotification(issue);
     expect(msg).toContain("$6,900");
     expect(msg).toContain("Algora");
+    expect(msg).toContain("✓ api / USD");
   });
 
   it("shows checkmark and OK for passed vetting", () => {
@@ -92,7 +97,7 @@ describe("formatBountyNotification", () => {
     expect(msg).not.toContain("Proposals: 15");
   });
 
-  it("shows (Boss) for boss issues", () => {
+  it("shows (Boss) for boss issues with api confidence", () => {
     const issue = makeIssue({
       source: "boss",
       repo: "org/repo",
@@ -101,15 +106,18 @@ describe("formatBountyNotification", () => {
       url: "https://github.com/org/repo/issues/3",
       bounty_amount: 200,
       bounty_formatted: "$200",
+      bounty_confidence: "api",
+      bounty_currency: "USD",
       labels: [],
       body: "",
       comment_count: 0,
     });
     const result = formatBountyNotification(issue);
     expect(result).toContain("(Boss)");
+    expect(result).toContain("✓ api / USD");
   });
 
-  it("shows (Global) for github_search issues", () => {
+  it("shows (Global) for github_search issues with text_extract confidence", () => {
     const issue = makeIssue({
       source: "github_search",
       repo: "some-org/some-repo",
@@ -118,11 +126,20 @@ describe("formatBountyNotification", () => {
       url: "https://github.com/some-org/some-repo/issues/42",
       bounty_amount: 500,
       bounty_formatted: "$500",
+      bounty_confidence: "text_extract",
+      bounty_currency: "unknown",
       labels: ["bounty"],
       body: "",
       comment_count: 0,
     });
     const result = formatBountyNotification(issue);
     expect(result).toContain("(Global)");
+    expect(result).toContain("~ text_extract / unknown");
+  });
+
+  it("does not show confidence when bounty_confidence is not set", () => {
+    const issue = makeIssue({ bounty_confidence: undefined, bounty_currency: undefined });
+    const result = formatBountyNotification(issue);
+    expect(result).not.toContain("Bounty:");
   });
 });

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -13,6 +13,14 @@ export function formatBountyNotification(
     : "";
   const tech = issue.tech?.length ? `\nTech: ${issue.tech.join(", ")}` : "";
 
+  // Confidence indicator
+  let confidence = "";
+  if (issue.bounty_confidence) {
+    const icon = issue.bounty_confidence === "api" ? "✓" : "~";
+    const currency = issue.bounty_currency ?? "unknown";
+    confidence = `\nBounty: ${icon} ${issue.bounty_confidence} / ${currency}`;
+  }
+
   // Use verified proposal count when available, fall back to raw comment count
   const proposalCount = vetResult
     ? vetResult.proposal_count
@@ -39,7 +47,7 @@ export function formatBountyNotification(
   return [
     `${prefix} ${issue.repo} #${issue.number}${bounty}${source}`,
     `"${issue.title}"`,
-    `${labels}${tech}${proposals}${vetLine}`,
+    `${labels}${tech}${confidence}${proposals}${vetLine}`,
     `\n${issue.url}`,
     `\nReply "skip" to dismiss`,
   ].join("\n");

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,6 +160,8 @@ export interface BountyIssue {
   url: string;
   bounty_amount?: number;
   bounty_formatted?: string;
+  bounty_confidence?: "api" | "text_extract";
+  bounty_currency?: "USD" | "unknown";
   labels: string[];
   assignees: string[];
   body: string;


### PR DESCRIPTION
## Description

Adds bounty confidence metadata fields (`bounty_confidence`, `bounty_currency`) to `BountyIssue` for cross-source sorting awareness.

### Changes
- `src/types.ts` — Added `bounty_confidence?: "api" | "text_extract"` and `bounty_currency?: "USD" | "unknown"` to BountyIssue
- `src/algora.ts` — Set `api` / `USD` for API-sourced bounties
- `src/boss.ts` — Set `api` / `USD` for API-sourced bounties
- `src/github.ts` — Set `text_extract` / `unknown` for text-extracted bounties
- `src/github-search.ts` — Set `text_extract` / `unknown` for text-extracted bounties
- `src/telegram.ts` — Optional confidence indicator in output
- Tests updated across all affected files

Closes #14