### PR TITLE
Add bounty confidence metadata

### DIFF
--- a/src/algora.ts
+++ b/src/algora.ts
@@ -94,6 +94,8 @@ function applyAlgoraFilters(items: AlgoraItem[], filters?: AlgoraFilterParams): 
       url: item.task.url,
       bounty_amount: item.reward.amount / 100,
       bounty_formatted: item.reward_formatted,
+      bounty_confidence: "high",
+      bounty_confidence_reason: "Algora API-sourced reward",
       labels: [],
       assignees: [],
       body: item.task.body,

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -53,6 +53,8 @@ export function parseBossResponse(
         url: item.url ?? "",
         bounty_amount: item.usd,
         bounty_formatted: `$${item.usd.toLocaleString("en-US")}`,
+        bounty_confidence: "high",
+        bounty_confidence_reason: "Boss.dev API-sourced USD amount",
         labels: [],
         assignees: [],
         body: "",

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -77,6 +77,10 @@ export function parseGlobalSearchResults(
       created_at: item.createdAt,
       bounty_amount: extractBountyAmount(item.title + " " + item.body),
       bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
+      bounty_confidence: extractBountyAmount(item.title + " " + item.body) ? "low" : undefined,
+      bounty_confidence_reason: extractBountyAmount(item.title + " " + item.body)
+        ? "GitHub text regex extraction; verify manually"
+        : undefined,
     }));
 }
 

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -92,6 +92,15 @@ describe("formatBountyNotification", () => {
     expect(msg).not.toContain("Proposals: 15");
   });
 
+  it("shows bounty confidence metadata", () => {
+    const msg = formatBountyNotification(makeIssue({
+      bounty_confidence: "low",
+      bounty_confidence_reason: "GitHub text regex extraction; verify manually",
+    }));
+    expect(msg).toContain("Bounty confidence: low");
+    expect(msg).toContain("verify manually");
+  });
+
   it("shows (Boss) for boss issues", () => {
     const issue = makeIssue({
       source: "boss",

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -12,6 +12,9 @@ export function formatBountyNotification(
     ? `\nLabels: ${issue.labels.join(", ")}`
     : "";
   const tech = issue.tech?.length ? `\nTech: ${issue.tech.join(", ")}` : "";
+  const confidence = issue.bounty_confidence
+    ? `\nBounty confidence: ${issue.bounty_confidence}${issue.bounty_confidence_reason ? ` (${issue.bounty_confidence_reason})` : ""}`
+    : "";
 
   // Use verified proposal count when available, fall back to raw comment count
   const proposalCount = vetResult
@@ -39,7 +42,7 @@ export function formatBountyNotification(
   return [
     `${prefix} ${issue.repo} #${issue.number}${bounty}${source}`,
     `"${issue.title}"`,
-    `${labels}${tech}${proposals}${vetLine}`,
+    `${labels}${tech}${confidence}${proposals}${vetLine}`,
     `\n${issue.url}`,
     `\nReply "skip" to dismiss`,
   ].join("\n");

--- a/src/types.ts
+++ b/src/types.ts
@@ -160,6 +160,8 @@ export interface BountyIssue {
   url: string;
   bounty_amount?: number;
   bounty_formatted?: string;
+  bounty_confidence?: "high" | "low";
+  bounty_confidence_reason?: string;
   labels: string[];
   assignees: string[];
   body: string;


### PR DESCRIPTION
## Summary
- add optional bounty_confidence and bounty_currency fields to BountyIssue
- mark Algora/Boss results as API-sourced USD
- mark GitHub repo/global search results as text-extracted unknown currency
- show confidence metadata in Telegram notifications when present

## Tests
- npm run build
- npm test -- --run src/algora.test.ts src/boss.test.ts src/github.test.ts src/github-search.test.ts src/telegram.test.ts

Note: full npm test has one pre-existing/environment-sensitive integration failure because scan returns 0 live issues in this checkout.