### PR TITLE
fix(#14): add bounty confidence metadata (api/text_extract) + currency to BountyIssue

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -65,6 +65,8 @@ export function fetchRepoIssues(repo: string, labels: string[]): BountyIssue[] {
     comment_count: issue.commentsCount,
     created_at: issue.createdAt,
     bounty_amount: extractBountyAmount(issue.title + " " + issue.body),
+    bounty_confidence: "text_extract" as const,
+    bounty_currency: "unknown" as const,
     bounty_formatted: extractBountyFormatted(issue.title),
   }));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,11 @@ export interface BountyIssue {
   comment_count: number;
   created_at: string;
   tech?: string[];
+  /** Confidence of the bounty amount source. "api" = validated, "text_extract" = regex from title/body */
+  bounty_confidence?: "api" | "text_extract";
+  /** Currency of the bounty amount */
+  bounty_currency?: "USD" | "unknown";
+
 }
 
 export type GitHubAuthorAssociation =


### PR DESCRIPTION
## Fix #14: Bounty Confidence Metadata

### Changes
- `src/types.ts`: Added `bounty_confidence?: "api" | "text_extract"` and `bounty_currency?: "USD" | "unknown"` to BountyIssue
- `src/boss.ts`: Set `bounty_confidence: "api"`, `bounty_currency: "USD"` 
- `src/github.ts`: Set `bounty_confidence: "text_extract"`, `bounty_currency: "unknown"`

### Why
Enables downstream consumers to sort bounties with awareness of data quality.

Closes #14
Wallet: `0xd474acf0dA4eF7409019A1B01fCB3deb30c27c57`