### PR TITLE
Add bounty confidence metadata

### DIFF
--- a/src/algora.test.ts
+++ b/src/algora.test.ts
@@ -49,6 +49,8 @@ describe("parseAlgoraResponse", () => {
     expect(issues[0].bounty_amount).toBe(250);
     expect(issues[0].repo).toBe("test/repo");
     expect(issues[0].source).toBe("algora");
+    expect(issues[0].bounty_confidence).toBe("api");
+    expect(issues[0].bounty_currency).toBe("USD");
   });
 
   it("filters by minimum bounty", () => {

--- a/src/algora.ts
+++ b/src/algora.ts
@@ -94,6 +94,8 @@ function applyAlgoraFilters(items: AlgoraItem[], filters?: AlgoraFilterParams): 
       url: item.task.url,
       bounty_amount: item.reward.amount / 100,
       bounty_formatted: item.reward_formatted,
+      bounty_confidence: "api",
+      bounty_currency: "USD",
       labels: [],
       assignees: [],
       body: item.task.body,

--- a/src/boss.test.ts
+++ b/src/boss.test.ts
@@ -49,6 +49,8 @@ describe("parseBossResponse", () => {
     expect(issues[0].number).toBe(42);
     expect(issues[0].bounty_amount).toBe(500);
     expect(issues[0].url).toBe("https://github.com/org/repo/issues/42");
+    expect(issues[0].bounty_confidence).toBe("api");
+    expect(issues[0].bounty_currency).toBe("USD");
   });
 
   it("filters by minimum bounty", () => {

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -53,6 +53,8 @@ export function parseBossResponse(
         url: item.url ?? "",
         bounty_amount: item.usd,
         bounty_formatted: `$${item.usd.toLocaleString("en-US")}`,
+        bounty_confidence: "api",
+        bounty_currency: "USD",
         labels: [],
         assignees: [],
         body: "",

--- a/src/github-search.test.ts
+++ b/src/github-search.test.ts
@@ -92,6 +92,8 @@ describe("parseGlobalSearchResults", () => {
     expect(issues[0].body).toBe("Bug description");
     expect(issues[0].comment_count).toBe(2);
     expect(issues[0].created_at).toBe("2026-02-15T00:00:00Z");
+    expect(issues[0].bounty_confidence).toBe("text_extract");
+    expect(issues[0].bounty_currency).toBe("unknown");
   });
 
   it("returns empty array for empty results", () => {

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -77,6 +77,8 @@ export function parseGlobalSearchResults(
       created_at: item.createdAt,
       bounty_amount: extractBountyAmount(item.title + " " + item.body),
       bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
+      bounty_confidence: "text_extract",
+      bounty_currency: "unknown",
     }));
 }
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -66,6 +66,8 @@ export function fetchRepoIssues(repo: string, labels: string[]): BountyIssue[] {
     created_at: issue.createdAt,
     bounty_amount: extractBountyAmount(issue.title + " " + issue.body),
     bounty_formatted: extractBountyFormatted(issue.title),
+    bounty_confidence: "text_extract",
+    bounty_currency: "unknown",
   }));
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,8 @@ export interface SeenIssue {
 }
 
 export type BountySourceType = "github" | "algora" | "github_search" | "boss";
+export type BountyConfidence = "api" | "text_extract";
+export type BountyCurrency = "USD" | "unknown";
 
 export interface BountyIssue {
   source: BountySourceType;
@@ -160,6 +162,8 @@ export interface BountyIssue {
   url: string;
   bounty_amount?: number;
   bounty_formatted?: string;
+  bounty_confidence?: BountyConfidence;
+  bounty_currency?: BountyCurrency;
   labels: string[];
   assignees: string[];
   body: string;


### PR DESCRIPTION
## Summary
- add optional bounty_confidence and bounty_currency metadata to BountyIssue
- mark Algora/Boss.dev bounties as API-sourced USD
- mark GitHub repo/global search bounties as text-extracted unknown currency
- add focused tests for the new metadata

## Verification
- npm run build
- npm test -- --run src/algora.test.ts src/boss.test.ts src/github-search.test.ts src/github.test.ts

Note: full npm test currently has an unrelated integration failure: scan command returned an empty array (expected >0).