### PR TITLE
ci: add test workflow for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+      - run: npm run build
+
+      # integration.test.ts hits live APIs (gh search, Boss.dev) and depends on
+      # external state; excluded here until it is mock-based (issue 15).
+      - run: npx vitest run --exclude "**/integration.test.ts"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml`: build + unit test suite on every PR and push to main. The repo previously had no PR CI at all (only the bounty monitor cron), so nothing gated merges.

## Why

The open issue backlog is about to be worked through as a series of PRs, each gated on green CI. This is the gate.

## Notes

- `integration.test.ts` is excluded for now: it hits live APIs (gh search, Boss.dev) and currently fails on dry sources. Issue 15 tracks converting it to mocks, after which it joins CI.
- Verified locally: the exact CI command runs 10 test files, 177 tests, all passing, with vitest default excludes (node_modules, dist) intact.

## Test plan

- [x] `npm run build` passes locally
- [x] `npx vitest run --exclude "**/integration.test.ts"` passes locally (177 tests)
- [ ] This PR's own CI run goes green