### PR TITLE
fix: request comments instead of invalid commentsCount in issue metadata

### DIFF
--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -90,7 +90,8 @@ describe("buildIssueMetadataArgs", () => {
     expect(jsonFields).toContain("labels");
     expect(jsonFields).toContain("assignees");
     expect(jsonFields).toContain("createdAt");
-    expect(jsonFields).toContain("commentsCount");
+    expect(jsonFields).toContain("comments");
+    expect(jsonFields).not.toContain("commentsCount");
   });
 
   it("uses --repo flag for the repo", () => {
@@ -108,12 +109,19 @@ describe("buildIssueMetadataArgs", () => {
 
 describe("fetchIssueMetadata", () => {
   it("parses GitHub API response into IssueMetadata", async () => {
+    // gh issue view --json has no commentsCount field; comments is an array
     const mockResponse = JSON.stringify({
       body: "Fix the login bug",
       labels: [{ name: "bug" }, { name: "Help Wanted" }],
       assignees: [{ login: "alice" }, { login: "bob" }],
       createdAt: "2025-01-15T10:00:00Z",
-      commentsCount: 5,
+      comments: [
+        { author: { login: "carol" }, body: "first" },
+        { author: { login: "dave" }, body: "second" },
+        { author: { login: "carol" }, body: "third" },
+        { author: { login: "erin" }, body: "fourth" },
+        { author: { login: "frank" }, body: "fifth" },
+      ],
     });
 
     mockExecFileSync.mockReturnValue(mockResponse);
@@ -144,7 +152,7 @@ describe("fetchIssueMetadata", () => {
       labels: [],
       assignees: [],
       createdAt: "2025-06-01T00:00:00Z",
-      commentsCount: 0,
+      comments: [],
     });
 
     mockExecFileSync.mockReturnValue(mockResponse);

--- a/src/github.ts
+++ b/src/github.ts
@@ -113,7 +113,8 @@ export function buildIssueMetadataArgs(repo: string, number: number): string[] {
     "--repo",
     repo,
     "--json",
-    "body,labels,assignees,createdAt,commentsCount",
+    // gh issue view has no commentsCount field; comments is an array
+    "body,labels,assignees,createdAt,comments",
   ];
 }
 
@@ -128,13 +129,13 @@ export function fetchIssueMetadata(
     labels: Array<{ name: string }>;
     assignees: Array<{ login: string }>;
     createdAt: string;
-    commentsCount: number;
+    comments: unknown[];
   };
   return {
     body: data.body,
     labels: data.labels.map((l) => l.name),
     assignees: data.assignees.map((a) => a.login),
-    comment_count: data.commentsCount,
+    comment_count: data.comments.length,
     created_at: data.createdAt,
   };
 }


### PR DESCRIPTION
Fixes #24

## Summary

`fetchIssueMetadata` requested `commentsCount` from `gh issue view --json`, which is not a valid field for that command. Every Boss.dev enrichment call failed with `Unknown JSON field`, and because the caller catches and warns, Boss issues silently kept their stub data: `created_at` pinned to fetch time (so the freshness filter never aged them out), `comment_count` 0, empty body (so vetting ran on nothing).

Now requests the `comments` array and derives the count from its length.

## Test plan

- [x] Updated mocks to the real `gh issue view` response shape; tests assert `comments` requested, `commentsCount` absent, count derived from array length
- [x] Full unit suite passes (177 tests) + tsc
- [x] Live verification: `fetchIssueMetadata("jbilcke-hf/clapper", 5)` now returns real metadata (comment_count 29, created_at 2024-06-18) where it previously threw