### PR TITLE
chore: enable Boss.dev source by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ sources:
 | `sources.algora.min_bounty` | Minimum bounty amount in USD (Algora amounts are in cents internally) |
 | `sources.algora.languages` | Only match bounties tagged with these languages (empty = all) |
 | `sources.algora.keywords_exclude` | Skip Algora bounties containing these keywords |
+| `sources.boss.enabled` | Whether to poll Boss.dev for bounties (default `true`; currently the most reliable source) |
+| `sources.boss.min_bounty` | Minimum bounty amount in USD (0 = no minimum) |
 
 ### Telegram Setup
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,8 @@ export const GitHubSearchSourceSchema = z.object({
 });
 
 export const BossSourceSchema = z.object({
-  enabled: z.boolean().default(false),
+  // Enabled by default: Boss.dev is currently the most reliable bounty source
+  enabled: z.boolean().default(true),
   min_bounty: z.number().default(0),
 });
 

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -67,9 +67,10 @@ sources:
     keywords_exclude: []
 
   # Boss.dev — bounties for open source software
-  # https://boss.dev — small catalog but platform-confirmed bounties
+  # https://boss.dev — small catalog but platform-confirmed bounties,
+  # currently the most reliable source
   boss:
-    enabled: false             # Set to true to enable Boss.dev polling
+    enabled: true              # Set to false to disable Boss.dev polling
     min_bounty: 50             # Minimum bounty amount in USD (0 = no minimum)
 
   # GitHub Global Label Search — searches ALL of GitHub for bounty-labeled issues


### PR DESCRIPTION
Fixes #29

## Summary

Boss.dev becomes enabled-by-default: zod schema default (`src/types.ts`), `watchlist.example.yml`, and two new README config-table rows. A 2026-06-10 live check found it returning 11 real bounties while every other source produced zero usable results (Algora dry, watched-repo issues filtered out by defaults).

## Behavioral note

Configs with a `boss:` block that omits `enabled` (e.g. only `min_bounty` set) now resolve to enabled and start polling on upgrade. That opt-in is intentional. Configs with no `boss` block at all are unchanged (block is optional, `boss?.enabled` stays undefined), and explicit `enabled: false` is respected.

## Test plan

- [x] Full unit suite (177) + tsc pass
- [ ] CI green