### PR TITLE
feat: prune seen.json entries older than a retention window

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
 import { fetchRepoIssues, fetchIssueComments, fetchIssueMetadata } from "./github.js";
 import { fetchGlobalBounties } from "./github-search.js";
 import { fetchBossBounties, buildBossFilters } from "./boss.js";
-import { SeenStore } from "./seen.js";
+import { SeenStore, effectiveRetentionDays } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
 import { applyPreFilter, applyFreshnessFilter } from "./monitor.js";
 import { vetIssue } from "./vet.js";
@@ -27,7 +27,10 @@ async function main() {
       const config = loadConfig();
       const dataDir = getDataDir();
       ensureDataDir(dataDir);
-      const seen = new SeenStore(join(dataDir, "seen.json"));
+      const seen = new SeenStore(
+        join(dataDir, "seen.json"),
+        effectiveRetentionDays(config.seen_retention_days, config.filters.max_age_days)
+      );
       const vettingEnabled = config.vetting.enabled;
       const allIssues: ScanResult[] = [];
       const seenThisScan = new Set<string>();
@@ -207,7 +210,7 @@ async function main() {
     case "seen": {
       const dataDir = getDataDir();
       ensureDataDir(dataDir);
-      const seen = new SeenStore(join(dataDir, "seen.json"));
+      const seen = new SeenStore(join(dataDir, "seen.json")); // manual state tool: never prunes
       if (args[1] === "--add") {
         const idArg = args[2] ?? "";
         const hashIdx = idArg.lastIndexOf("#");

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -60,6 +60,22 @@ sources:
 `;
     writeFileSync(join(dataDir, "watchlist.yml"), config);
 
+    // Seed a seen entry older than the 90-day retention default. The prune
+    // fires during scan and must log to stderr, keeping --json stdout parseable.
+    writeFileSync(
+      join(dataDir, "seen.json"),
+      JSON.stringify([
+        {
+          id: "Expensify/App#1",
+          repo: "Expensify/App",
+          number: 1,
+          title: "Ancient seen entry",
+          seen_at: new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString(),
+          skipped: false,
+        },
+      ])
+    );
+
     // One day old: inside the 7-day freshness window on every run
     const createdAt = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
     writeGhShim(

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -4,7 +4,7 @@ import { loadConfig, ensureDataDir, getDataDir } from "./config.js";
 import { fetchRepoIssues, fetchIssueComments, fetchIssueMetadata } from "./github.js";
 import { fetchGlobalBounties } from "./github-search.js";
 import { fetchBossBounties, buildBossFilters } from "./boss.js";
-import { SeenStore } from "./seen.js";
+import { SeenStore, effectiveRetentionDays } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
 import { vetIssue } from "./vet.js";
 import type {
@@ -73,7 +73,10 @@ export async function runMonitor(): Promise<void> {
   const config = loadConfig();
   const dataDir = getDataDir();
   ensureDataDir(dataDir);
-  const seen = new SeenStore(join(dataDir, "seen.json"));
+  const seen = new SeenStore(
+    join(dataDir, "seen.json"),
+    effectiveRetentionDays(config.seen_retention_days, config.filters.max_age_days)
+  );
   const vettingEnabled = config.vetting.enabled;
 
   const allNew: Array<{ issue: BountyIssue; vetResult?: VetResult }> = [];

--- a/src/seen.test.ts
+++ b/src/seen.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { SeenStore } from "./seen.js";
-import { mkdirSync, rmSync } from "node:fs";
+import { SeenStore, effectiveRetentionDays } from "./seen.js";
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import type { BountyIssue } from "./types.js";
 
@@ -69,5 +69,100 @@ describe("SeenStore", () => {
     };
     store.markSeenFromBounty(bountyIssue);
     expect(store.hasSeen("Expensify/App", 99999)).toBe(true);
+  });
+});
+
+describe("SeenStore retention pruning", () => {
+  const path = join(TEST_DIR, "seen.json");
+
+  function entry(number: number, ageDays: number) {
+    return {
+      id: `Expensify/App#${number}`,
+      repo: "Expensify/App",
+      number,
+      title: `Issue ${number}`,
+      seen_at: new Date(Date.now() - ageDays * 24 * 60 * 60 * 1000).toISOString(),
+      skipped: false,
+    };
+  }
+
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const writer = new SeenStore(path);
+    writer.markSeen(entry(1, 120)); // older than retention
+    writer.markSeen(entry(2, 5)); // fresh
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("prunes entries older than retention on load", () => {
+    const store = new SeenStore(path, 90);
+    expect(store.hasSeen("Expensify/App", 1)).toBe(false);
+    expect(store.hasSeen("Expensify/App", 2)).toBe(true);
+  });
+
+  it("persists the prune to disk", () => {
+    new SeenStore(path, 90);
+    // Reload with pruning disabled: the old entry must be gone from the file
+    const reread = new SeenStore(path);
+    expect(reread.hasSeen("Expensify/App", 1)).toBe(false);
+    expect(reread.hasSeen("Expensify/App", 2)).toBe(true);
+  });
+
+  it("keeps everything when retention is 0", () => {
+    const store = new SeenStore(path, 0);
+    expect(store.hasSeen("Expensify/App", 1)).toBe(true);
+    expect(store.hasSeen("Expensify/App", 2)).toBe(true);
+  });
+
+  it("keeps everything when retention is omitted", () => {
+    const store = new SeenStore(path);
+    expect(store.hasSeen("Expensify/App", 1)).toBe(true);
+    expect(store.hasSeen("Expensify/App", 2)).toBe(true);
+  });
+
+  it("keeps entries with unparseable seen_at timestamps", () => {
+    const writer = new SeenStore(path);
+    writer.markSeen({ ...entry(3, 0), seen_at: "not-a-date" });
+    const store = new SeenStore(path, 90);
+    expect(store.hasSeen("Expensify/App", 3)).toBe(true);
+  });
+
+  it("does not leave a temp file behind after saving", () => {
+    new SeenStore(path, 90); // triggers a prune-save
+    expect(existsSync(`${path}.tmp`)).toBe(false);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("throws a descriptive error on corrupt seen.json instead of starting empty", () => {
+    writeFileSync(path, "not valid json");
+    expect(() => new SeenStore(path, 90)).toThrow(/corrupt/);
+    // The corrupt file must survive for manual recovery
+    expect(readFileSync(path, "utf-8")).toBe("not valid json");
+  });
+
+  it("throws when seen.json is valid JSON but not an array", () => {
+    writeFileSync(path, JSON.stringify({ nope: true }));
+    expect(() => new SeenStore(path)).toThrow(/expected a JSON array/);
+  });
+});
+
+describe("effectiveRetentionDays", () => {
+  it("returns retention when it exceeds the freshness window", () => {
+    expect(effectiveRetentionDays(90, 7)).toBe(90);
+  });
+
+  it("floors retention at max_age_days so pruning can never cause re-notification", () => {
+    expect(effectiveRetentionDays(5, 30)).toBe(30);
+  });
+
+  it("returns 0 (never prune) when retention is 0, regardless of max_age_days", () => {
+    expect(effectiveRetentionDays(0, 7)).toBe(0);
+  });
+
+  it("handles a disabled freshness window", () => {
+    expect(effectiveRetentionDays(90, 0)).toBe(90);
   });
 });

--- a/src/seen.ts
+++ b/src/seen.ts
@@ -1,26 +1,77 @@
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, renameSync } from "node:fs";
 import type { BountyIssue, SeenIssue } from "./types.js";
+
+/**
+ * Resolves the retention window actually used for pruning. Retention is
+ * floored at max_age_days so an entry can never be pruned while its issue
+ * is still inside the freshness window (which would let it re-notify).
+ * A retention of 0 always means "never prune".
+ */
+export function effectiveRetentionDays(
+  retentionDays: number,
+  maxAgeDays: number
+): number {
+  if (retentionDays === 0) return 0;
+  return Math.max(retentionDays, maxAgeDays);
+}
 
 export class SeenStore {
   private path: string;
   private data: Map<string, SeenIssue>;
+  private retentionDays: number;
 
-  constructor(path: string) {
+  constructor(path: string, retentionDays = 0) {
     this.path = path;
     this.data = new Map();
+    this.retentionDays = retentionDays;
     this.load();
   }
 
   private load(): void {
     if (!existsSync(this.path)) return;
-    const raw = JSON.parse(readFileSync(this.path, "utf-8")) as SeenIssue[];
+    let raw: SeenIssue[];
+    try {
+      const parsed = JSON.parse(readFileSync(this.path, "utf-8"));
+      if (!Array.isArray(parsed)) throw new Error("expected a JSON array");
+      raw = parsed as SeenIssue[];
+    } catch (err) {
+      // Fail loudly rather than starting with an empty store, which would
+      // silently re-notify every previously seen bounty.
+      throw new Error(
+        `SeenStore: ${this.path} is corrupt (${err instanceof Error ? err.message : err}). ` +
+          `Fix or delete the file (deleting will re-notify all previously seen bounties).`
+      );
+    }
+    const cutoff =
+      this.retentionDays > 0
+        ? Date.now() - this.retentionDays * 24 * 60 * 60 * 1000
+        : undefined;
+    let pruned = 0;
     for (const issue of raw) {
+      if (cutoff !== undefined) {
+        const seenAt = new Date(issue.seen_at).getTime();
+        // NaN comparisons are false, so unparseable timestamps are kept
+        if (seenAt < cutoff) {
+          pruned++;
+          continue;
+        }
+      }
       this.data.set(issue.id, issue);
+    }
+    if (pruned > 0) {
+      // stderr: scan --json emits machine-readable output on stdout
+      console.error(
+        `SeenStore: pruned ${pruned} entries older than ${this.retentionDays} days from ${this.path}`
+      );
+      this.save();
     }
   }
 
   private save(): void {
-    writeFileSync(this.path, JSON.stringify([...this.data.values()], null, 2));
+    // Write-then-rename so a crash mid-write can never truncate the live file
+    const tmp = `${this.path}.tmp`;
+    writeFileSync(tmp, JSON.stringify([...this.data.values()], null, 2));
+    renameSync(tmp, this.path);
   }
 
   private makeId(repo: string, number: number): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,8 @@ export const VettingConfigSchema = z.object({
 
 export const WatchlistConfigSchema = z.object({
   polling_interval: z.number(),
+  // Days to keep seen.json entries before pruning on load (0 = never prune)
+  seen_retention_days: z.number().int().nonnegative().default(90),
   telegram: TelegramConfigSchema,
   sources: z.object({
     repos: z.array(RepoSourceSchema),

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -6,6 +6,11 @@
 
 polling_interval: 15
 
+# Days to keep seen.json entries before pruning on load (0 = never prune).
+# Pruning is floored at filters.max_age_days so a pruned issue can never
+# re-notify while still inside the freshness window.
+seen_retention_days: 90
+
 telegram:
   bot_token: "set-via-env"
   chat_id: "set-via-env"


### PR DESCRIPTION
Fixes #31

## Summary

`SeenStore` only ever grew, and every save rewrote the whole file. This adds a top-level `seen_retention_days` config (default 90, `0` = never prune) that prunes stale entries on load and persists the prune.

Safety properties, several from the review loop:

- **Retention is floored at `filters.max_age_days`** via `effectiveRetentionDays`, so a pruned entry can never belong to an issue still inside the freshness window (which would re-notify it)
- **Atomic save**: write-then-rename, so a crash mid-write can never truncate the live seen.json (the silent-failure review flagged that pruning turned load into a startup write, making the pre-existing non-atomic save genuinely dangerous)
- **Corrupt seen.json fails loudly** with the path and recovery guidance instead of silently starting an empty store and re-notifying every bounty ever seen; the corrupt bytes survive for manual recovery
- **Prune logs to stderr**, keeping `scan --json` stdout machine-parseable (second-pass review catch; integration test now seeds a stale entry so the prune fires during a JSON scan)
- The manual `seen` subcommand never prunes; schema rejects negative/fractional retention

## Test plan

- [x] 9 new unit tests (prune, persistence, retention 0/omitted, NaN timestamps, corrupt file, non-array JSON, no .tmp residue) + 4 helper tests + integration prune-during-json-scan case
- [x] Full suite: 10 files, 176 tests, tsc clean
- [ ] CI green