### PR TITLE
feat: per-repo overrides for the freshness filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ sources:
 | `sources.repos[].labels` | Only match issues with these labels |
 | `sources.repos[].proposal_template` | Which template to use: `expensify`, `default`, or `auto` |
 | `sources.repos[].pre_filter.keywords_exclude` | Skip issues whose title or body contains these keywords |
+| `sources.repos[].filters` | Per-repo overrides of the global `filters` block (`max_age_days`, `skip_assigned`, `claimed_labels`, `max_comment_count`). Needed for repos like Expensify/App that auto-assign and bot-comment on every issue, which the global defaults would drop entirely |
 | `sources.boss.enabled` | Whether to poll Boss.dev for bounties (default `true`; currently the most reliable source) |
 | `sources.boss.min_bounty` | Minimum bounty amount in USD (0 = no minimum) |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { fetchGlobalBounties } from "./github-search.js";
 import { fetchBossBounties, buildBossFilters } from "./boss.js";
 import { SeenStore, effectiveRetentionDays } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
-import { applyPreFilter, applyFreshnessFilter } from "./monitor.js";
+import { applyPreFilter, applyFreshnessFilter, resolveRepoFilters } from "./monitor.js";
 import { vetIssue } from "./vet.js";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
@@ -36,6 +36,7 @@ async function main() {
       const seenThisScan = new Set<string>();
 
       for (const repo of config.sources.repos) {
+        const repoFilters = resolveRepoFilters(config.filters, repo.filters);
         let issues: BountyIssue[];
         try {
           issues = fetchRepoIssues(repo.name, repo.labels);
@@ -48,7 +49,7 @@ async function main() {
           if (seenThisScan.has(issueKey)) continue;
           seenThisScan.add(issueKey);
           if (!applyPreFilter(issue, repo.pre_filter)) continue;
-          if (!applyFreshnessFilter(issue, config.filters)) continue;
+          if (!applyFreshnessFilter(issue, repoFilters)) continue;
 
           let vetResult: VetResult | undefined;
           if (vettingEnabled) {

--- a/src/monitor.test.ts
+++ b/src/monitor.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { applyPreFilter, applyFreshnessFilter, shouldNotify } from "./monitor.js";
+import {
+  applyPreFilter,
+  applyFreshnessFilter,
+  resolveRepoFilters,
+  shouldNotify,
+} from "./monitor.js";
 import type { BountyIssue, Filters, VetResult } from "./types.js";
 
 const makeIssue = (overrides: Partial<BountyIssue> = {}): BountyIssue => ({
@@ -229,5 +234,48 @@ describe("shouldNotify", () => {
   it("notifies on failed vetting with on_fail=notify_all", () => {
     const failed = makeVetResult(false);
     expect(shouldNotify(failed, "notify_all")).toBe(true);
+  });
+});
+
+describe("resolveRepoFilters", () => {
+  it("returns global filters when no override is given", () => {
+    expect(resolveRepoFilters(defaultFilters, undefined)).toEqual(defaultFilters);
+  });
+
+  it("applies only the overridden keys", () => {
+    const resolved = resolveRepoFilters(defaultFilters, {
+      skip_assigned: false,
+      max_comment_count: 0,
+    });
+    expect(resolved.skip_assigned).toBe(false);
+    expect(resolved.max_comment_count).toBe(0);
+    expect(resolved.max_age_days).toBe(defaultFilters.max_age_days);
+    expect(resolved.claimed_labels).toEqual(defaultFilters.claimed_labels);
+  });
+
+  it("does not mutate the global filters object", () => {
+    const global = { ...defaultFilters };
+    resolveRepoFilters(global, { skip_assigned: false });
+    expect(global.skip_assigned).toBe(true);
+  });
+
+  it("lets an Expensify-style issue pass with assignee and comment overrides", () => {
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
+    // The shape that previously dropped 100% of Expensify bounties:
+    // auto-assigned internal engineer plus an instant bot comment storm
+    const issue = makeIssue({ assignees: ["internal-engineer"], comment_count: 26 });
+    expect(applyFreshnessFilter(issue, defaultFilters)).toBe(false);
+    const resolved = resolveRepoFilters(defaultFilters, {
+      skip_assigned: false,
+      max_comment_count: 0,
+    });
+    expect(applyFreshnessFilter(issue, resolved)).toBe(true);
+  });
+
+  it("still applies claimed-label drops under overrides", () => {
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-02-06T00:00:00Z").getTime());
+    const issue = makeIssue({ labels: ["Help Wanted", "Reviewing"] });
+    const resolved = resolveRepoFilters(defaultFilters, { skip_assigned: false });
+    expect(applyFreshnessFilter(issue, resolved)).toBe(false);
   });
 });

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -10,6 +10,7 @@ import { vetIssue } from "./vet.js";
 import type {
   BountyIssue,
   Filters,
+  FiltersOverride,
   RepoSource,
   VetResult,
   VettingConfig,
@@ -19,6 +20,18 @@ export function applyPreFilter(issue: BountyIssue, filter: RepoSource["pre_filte
   if (!filter?.keywords_exclude?.length) return true;
   const text = (issue.title + " " + issue.body).toLowerCase();
   return !filter.keywords_exclude.some((kw) => text.includes(kw.toLowerCase()));
+}
+
+/**
+ * Merges a repo's filter overrides onto the global filters. Only keys the
+ * repo explicitly sets are overridden; everything else stays global.
+ */
+export function resolveRepoFilters(
+  global: Filters,
+  override: FiltersOverride | undefined
+): Filters {
+  if (!override) return global;
+  return { ...global, ...override };
 }
 
 export function applyFreshnessFilter(issue: BountyIssue, filters: Filters): boolean {
@@ -84,11 +97,12 @@ export async function runMonitor(): Promise<void> {
   // Poll GitHub repos
   for (const repo of config.sources.repos) {
     try {
+      const repoFilters = resolveRepoFilters(config.filters, repo.filters);
       const issues = fetchRepoIssues(repo.name, repo.labels);
       for (const issue of issues) {
         if (seen.hasSeen(issue.repo, issue.number)) continue;
         if (!applyPreFilter(issue, repo.pre_filter)) continue;
-        if (!applyFreshnessFilter(issue, config.filters)) continue;
+        if (!applyFreshnessFilter(issue, repoFilters)) continue;
 
         // Mark seen regardless of vetting outcome to prevent re-checking
         seen.markSeenFromBounty(issue);

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,15 @@ import { z } from "zod";
 
 // --- Config schemas (Zod = single source of truth) ---
 
+const FiltersOverrideSchema = z
+  .object({
+    max_age_days: z.number(),
+    claimed_labels: z.array(z.string()),
+    max_comment_count: z.number(),
+    skip_assigned: z.boolean(),
+  })
+  .partial();
+
 const RepoSourceSchema = z.object({
   name: z.string(),
   labels: z.array(z.string()),
@@ -11,7 +20,13 @@ const RepoSourceSchema = z.object({
       keywords_exclude: z.array(z.string()).optional(),
     })
     .optional(),
+  // Per-repo overrides of the global filters block. Repos like Expensify/App
+  // auto-assign an engineer and accumulate bot comments within minutes, so
+  // the global skip_assigned / max_comment_count defaults drop everything.
+  filters: FiltersOverrideSchema.optional(),
 });
+
+export type FiltersOverride = z.infer<typeof FiltersOverrideSchema>;
 
 export const GitHubSearchSourceSchema = z.object({
   enabled: z.boolean().default(false),

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -64,6 +64,13 @@ sources:
       pre_filter:
         keywords_exclude:
           - "NewDot"
+      # Expensify auto-assigns an internal engineer to every external issue
+      # and bot comments arrive within minutes, so the global skip_assigned /
+      # max_comment_count defaults would drop 100% of its bounties. Override
+      # them here; vetting's max_proposals still gauges real competition.
+      filters:
+        skip_assigned: false
+        max_comment_count: 0
 
   # Boss.dev — bounties for open source software
   # https://boss.dev — small catalog but platform-confirmed bounties,


### PR DESCRIPTION
Fixes #25

## Summary

The audit's biggest finding: the Expensify source never produced a notification because every Expensify Help Wanted issue carries an auto-assigned internal engineer (killed by `skip_assigned: true`) and 20-43 bot/proposal comments within hours (killed by `max_comment_count: 5`). Filters were global-only, so there was no way to express "this repo behaves differently."

- `sources.repos[].filters` accepts a partial override of the global filters block (`max_age_days`, `skip_assigned`, `claimed_labels`, `max_comment_count`)
- `resolveRepoFilters` merges override keys onto globals; absent keys stay global (zod `.partial()` verified to omit absent keys rather than inject undefined)
- Both repo loops (monitor + scan) use the resolved filters; github_search and Boss.dev keep globals
- Example config ships Expensify with `skip_assigned: false`, `max_comment_count: 0`, with vetting's `max_proposals` still gauging real competition

## Live verification

Against Expensify/App today: 20 issues fetched, 0 survive the global defaults, 20 survive with the overrides (claimed-label and age checks still active).

## Test plan

- [x] 5 new tests: merge semantics, non-mutation, Expensify-shape pass-through, claimed-labels still enforced under overrides
- [x] Full suite 181 tests, tsc clean
- [ ] CI green