### PR TITLE
feat: precision-first defaults for GitHub global search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ templates/
 - `BountyIssue` — normalized issue from GitHub, GitHub Global Search, or Boss.dev (source: "github" | "github_search" | "boss")
 - `WatchlistConfig` — top-level config shape (polling_interval, telegram, sources, filters, vetting)
 - `RepoSource` — individual GitHub repo config (name, labels, proposal_template, pre_filter)
-- `GitHubSearchSource` — GitHub Global Search config (enabled, labels, languages, min_stars, keywords_exclude, max_results)
+- `GitHubSearchSource` — GitHub Global Search config (enabled, labels, languages, min_stars, keywords_exclude, repos_exclude, require_bounty_amount, max_results)
 - `BossSource` — Boss.dev config (enabled, min_bounty)
 - `SeenIssue` — deduplication record (id, repo, number, title, seen_at, skipped)
 - `TelegramConfig` — bot_token + chat_id

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ sources:
 | `sources.repos[].filters` | Per-repo overrides of the global `filters` block (`max_age_days`, `skip_assigned`, `claimed_labels`, `max_comment_count`). Needed for repos like Expensify/App that auto-assign and bot-comment on every issue, which the global defaults would drop entirely |
 | `sources.boss.enabled` | Whether to poll Boss.dev for bounties (default `true`; currently the most reliable source) |
 | `sources.boss.min_bounty` | Minimum bounty amount in USD (0 = no minimum) |
+| `sources.github_search.enabled` | Whether to search all of GitHub for bounty-labeled issues (default `false`) |
+| `sources.github_search.min_stars` | Only include repos with at least N stars (default `200`; bounty-farm repos dominate below that) |
+| `sources.github_search.repos_exclude` | Blocklist of `owner/repo` to always skip |
+| `sources.github_search.require_bounty_amount` | Drop issues with no detected `$` amount in title or body (default `true`) |
 
 ### Telegram Setup
 

--- a/src/github-search.test.ts
+++ b/src/github-search.test.ts
@@ -8,6 +8,8 @@ const defaultConfig: GitHubSearchSource = {
   languages: [],
   min_stars: 0,
   keywords_exclude: [],
+  repos_exclude: [],
+  require_bounty_amount: false,
   max_results: 50,
 };
 
@@ -104,6 +106,32 @@ describe("parseGlobalSearchResults", () => {
     const raw = mockSearchResult({ repository: { nameWithOwner: "small/repo", stargazerCount: 10 } });
     const issues = parseGlobalSearchResults(raw, config);
     expect(issues).toHaveLength(0);
+  });
+
+  it("filters by repos_exclude blocklist", () => {
+    const config = { ...defaultConfig, repos_exclude: ["waxeye7/screeps-bounty-arena"] };
+    const raw = mockSearchResult({
+      repository: { nameWithOwner: "waxeye7/screeps-bounty-arena", stargazerCount: 999 },
+    });
+    expect(parseGlobalSearchResults(raw, config)).toHaveLength(0);
+    // Non-blocked repos still pass
+    expect(parseGlobalSearchResults(mockSearchResult(), config)).toHaveLength(1);
+  });
+
+  it("drops issues without a detected dollar amount when require_bounty_amount is set", () => {
+    const config = { ...defaultConfig, require_bounty_amount: true };
+    const noAmount = mockSearchResult({ title: "bug-hunt: find the regression", body: "no payout mentioned" });
+    expect(parseGlobalSearchResults(noAmount, config)).toHaveLength(0);
+    // Amount in title passes
+    expect(parseGlobalSearchResults(mockSearchResult(), config)).toHaveLength(1);
+    // Amount only in body passes too
+    const bodyAmount = mockSearchResult({ title: "Fix the bug", body: "Bounty: $250 on completion" });
+    expect(parseGlobalSearchResults(bodyAmount, config)).toHaveLength(1);
+  });
+
+  it("keeps issues without amounts when require_bounty_amount is off", () => {
+    const noAmount = mockSearchResult({ title: "bug-hunt: find the regression", body: "no payout" });
+    expect(parseGlobalSearchResults(noAmount, defaultConfig)).toHaveLength(1);
   });
 
   it("filters by keywords_exclude in title", () => {

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -56,11 +56,20 @@ export function parseGlobalSearchResults(
       if (watchedRepos?.includes(item.repository.nameWithOwner)) {
         return false;
       }
+      if (config.repos_exclude.includes(item.repository.nameWithOwner)) {
+        return false;
+      }
       if (config.keywords_exclude.length > 0) {
         const text = (item.title + " " + item.body).toLowerCase();
         if (config.keywords_exclude.some((kw) => text.includes(kw.toLowerCase()))) {
           return false;
         }
+      }
+      if (
+        config.require_bounty_amount &&
+        extractBountyAmount(item.title + " " + item.body) === undefined
+      ) {
+        return false;
       }
       return true;
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,8 +32,12 @@ export const GitHubSearchSourceSchema = z.object({
   enabled: z.boolean().default(false),
   labels: z.array(z.string()).default(["bounty"]),
   languages: z.array(z.string()).default([]),
-  min_stars: z.number().default(0),
+  // Precision-first defaults: global search sweeps all of GitHub, where
+  // low-star gamified "bounty" repos with no real payouts dominate results
+  min_stars: z.number().default(200),
   keywords_exclude: z.array(z.string()).default([]),
+  repos_exclude: z.array(z.string()).default([]),
+  require_bounty_amount: z.boolean().default(true),
   max_results: z.number().default(50),
 });
 

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -80,7 +80,9 @@ sources:
     min_bounty: 50             # Minimum bounty amount in USD (0 = no minimum)
 
   # GitHub Global Label Search — searches ALL of GitHub for bounty-labeled issues
-  # This discovers bounties beyond your watched repos
+  # This discovers bounties beyond your watched repos. Defaults are
+  # precision-first: low-star gamified "bounty" repos with no real payouts
+  # dominate unfiltered results.
   github_search:
     enabled: false             # Set to true to enable global search
     labels:                    # GitHub labels to search for
@@ -90,6 +92,10 @@ sources:
       - typescript
       - python
       - go
-    min_stars: 50              # Only include repos with >= N stars (0 = disabled)
+    min_stars: 200             # Only include repos with >= N stars (0 = disabled)
     keywords_exclude: []       # Skip issues containing these keywords
+    repos_exclude:             # Blocklist of owner/repo to always skip (bounty farms)
+      - waxeye7/screeps-bounty-arena
+      - xevrion-v2/agent-playground
+    require_bounty_amount: true # Drop issues with no detected $ amount in title/body
     max_results: 50            # Max results per search


### PR DESCRIPTION
Fixes #30

## Summary

The github_search source surfaced junk: a live scan under the example defaults returned results exclusively from one gamified bounty-farm repo. Three changes, all precision-first (the source sweeps all of GitHub, and it's disabled by default so these only affect users who opt in):

- `min_stars` default 0 → 200 (schema) and 50 → 200 (example config)
- New `repos_exclude` blocklist, checked against `repository.nameWithOwner`; the example config seeds it with the two farms observed live, one of which clears 200 stars and posts fake dollar amounts ("$1000 calculate the exact value of PI")
- New `require_bounty_amount` (default `true`): drops issues with no detected `$` amount in title or body, reusing the existing extraction regex

## Live verification

Same query, old defaults vs new: 50 results → 18, with every screeps-farm issue eliminated by the amount requirement and the second farm caught by the blocklist.

## Test plan

- [x] 3 new tests: blocklist (blocks listed, passes others), amount requirement (drops no-amount, passes title-amount and body-amount, no-op when off)
- [x] Full suite 193 tests, tsc clean; README/CLAUDE.md/example config consistent with schema defaults
- [ ] CI green