### PR TITLE
feat: tag bounty amounts with source confidence

### DIFF
--- a/src/boss.test.ts
+++ b/src/boss.test.ts
@@ -145,3 +145,11 @@ describe("buildBossFilters", () => {
     expect(filters.min_bounty).toBeUndefined();
   });
 });
+
+describe("bounty confidence metadata", () => {
+  it("tags Boss amounts as api-confirmed USD", () => {
+    const issues = parseBossResponse([makeBossItem()]);
+    expect(issues[0].bounty_confidence).toBe("api");
+    expect(issues[0].bounty_currency).toBe("USD");
+  });
+});

--- a/src/boss.ts
+++ b/src/boss.ts
@@ -53,6 +53,8 @@ export function parseBossResponse(
         url: item.url ?? "",
         bounty_amount: item.usd,
         bounty_formatted: `$${item.usd.toLocaleString("en-US")}`,
+        bounty_confidence: "api" as const,
+        bounty_currency: "USD" as const,
         labels: [],
         assignees: [],
         body: "",

--- a/src/github-search.test.ts
+++ b/src/github-search.test.ts
@@ -194,3 +194,19 @@ describe("parseGlobalSearchResults", () => {
     expect(issues).toHaveLength(1);
   });
 });
+
+describe("bounty confidence metadata", () => {
+  it("tags extracted amounts as text_extract with unknown currency", () => {
+    const issues = parseGlobalSearchResults(mockSearchResult(), defaultConfig);
+    expect(issues[0].bounty_confidence).toBe("text_extract");
+    expect(issues[0].bounty_currency).toBe("unknown");
+  });
+
+  it("omits confidence metadata when no amount was extracted", () => {
+    const raw = mockSearchResult({ title: "Fix the bug", body: "no amount here" });
+    const issues = parseGlobalSearchResults(raw, defaultConfig);
+    expect(issues[0].bounty_amount).toBeUndefined();
+    expect(issues[0].bounty_confidence).toBeUndefined();
+    expect(issues[0].bounty_currency).toBeUndefined();
+  });
+});

--- a/src/github-search.ts
+++ b/src/github-search.ts
@@ -73,20 +73,26 @@ export function parseGlobalSearchResults(
       }
       return true;
     })
-    .map((item) => ({
-      source: "github_search" as const,
-      repo: item.repository.nameWithOwner,
-      number: item.number,
-      title: item.title,
-      url: item.url,
-      labels: item.labels.map((l) => l.name),
-      assignees: item.assignees.map((a) => a.login),
-      body: item.body,
-      comment_count: item.commentsCount,
-      created_at: item.createdAt,
-      bounty_amount: extractBountyAmount(item.title + " " + item.body),
-      bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
-    }));
+    .map((item) => {
+      const bountyAmount = extractBountyAmount(item.title + " " + item.body);
+      return {
+        source: "github_search" as const,
+        repo: item.repository.nameWithOwner,
+        number: item.number,
+        title: item.title,
+        url: item.url,
+        labels: item.labels.map((l) => l.name),
+        assignees: item.assignees.map((a) => a.login),
+        body: item.body,
+        comment_count: item.commentsCount,
+        created_at: item.createdAt,
+        bounty_amount: bountyAmount,
+        bounty_formatted: extractBountyFormatted(item.title) ?? extractBountyFormatted(item.body),
+        ...(bountyAmount !== undefined
+          ? { bounty_confidence: "text_extract" as const, bounty_currency: "unknown" as const }
+          : {}),
+      };
+    });
 }
 
 export function fetchGlobalBounties(

--- a/src/github.ts
+++ b/src/github.ts
@@ -53,20 +53,26 @@ export function fetchRepoIssues(repo: string, labels: string[]): BountyIssue[] {
     commentsCount: number;
   }>;
 
-  return issues.map((issue) => ({
-    source: "github" as const,
-    repo,
-    number: issue.number,
-    title: issue.title,
-    url: issue.url,
-    labels: issue.labels.map((l) => l.name),
-    assignees: issue.assignees.map((a) => a.login),
-    body: issue.body,
-    comment_count: issue.commentsCount,
-    created_at: issue.createdAt,
-    bounty_amount: extractBountyAmount(issue.title + " " + issue.body),
-    bounty_formatted: extractBountyFormatted(issue.title),
-  }));
+  return issues.map((issue) => {
+    const bountyAmount = extractBountyAmount(issue.title + " " + issue.body);
+    return {
+      source: "github" as const,
+      repo,
+      number: issue.number,
+      title: issue.title,
+      url: issue.url,
+      labels: issue.labels.map((l) => l.name),
+      assignees: issue.assignees.map((a) => a.login),
+      body: issue.body,
+      comment_count: issue.commentsCount,
+      created_at: issue.createdAt,
+      bounty_amount: bountyAmount,
+      bounty_formatted: extractBountyFormatted(issue.title),
+      ...(bountyAmount !== undefined
+        ? { bounty_confidence: "text_extract" as const, bounty_currency: "unknown" as const }
+        : {}),
+    };
+  });
 }
 
 export function buildIssueViewArgs(repo: string, number: number): string[] {

--- a/src/telegram.test.ts
+++ b/src/telegram.test.ts
@@ -106,4 +106,34 @@ describe("formatBountyNotification", () => {
     const result = formatBountyNotification(issue);
     expect(result).toContain("(Global)");
   });
+
+  it("marks text-extracted amounts with a tilde", () => {
+    const issue = makeIssue({
+      bounty_amount: 250,
+      bounty_formatted: "$250",
+      bounty_confidence: "text_extract",
+      bounty_currency: "unknown",
+    });
+    expect(formatBountyNotification(issue)).toContain("~$250");
+  });
+
+  it("shows API-confirmed amounts without a tilde", () => {
+    const issue = makeIssue({
+      source: "boss",
+      bounty_amount: 1000,
+      bounty_formatted: "$1,000",
+      bounty_confidence: "api",
+      bounty_currency: "USD",
+    });
+    const msg = formatBountyNotification(issue);
+    expect(msg).toContain("$1,000");
+    expect(msg).not.toContain("~$1,000");
+  });
+
+  it("shows legacy amounts without confidence metadata untouched", () => {
+    const issue = makeIssue({ bounty_amount: 250, bounty_formatted: "$250" });
+    const msg = formatBountyNotification(issue);
+    expect(msg).toContain("$250");
+    expect(msg).not.toContain("~$250");
+  });
 });

--- a/src/telegram.ts
+++ b/src/telegram.ts
@@ -7,7 +7,9 @@ export function formatBountyNotification(
   vetResult?: VetResult
 ): string {
   const source = issue.source === "github_search" ? " (Global)" : issue.source === "boss" ? " (Boss)" : "";
-  const bounty = issue.bounty_formatted ? ` — ${issue.bounty_formatted}` : "";
+  // Tilde marks regex-extracted amounts that no platform API has confirmed
+  const unverified = issue.bounty_confidence === "text_extract" ? "~" : "";
+  const bounty = issue.bounty_formatted ? ` — ${unverified}${issue.bounty_formatted}` : "";
   const labels = issue.labels.length
     ? `\nLabels: ${issue.labels.join(", ")}`
     : "";

--- a/src/types.ts
+++ b/src/types.ts
@@ -164,6 +164,11 @@ export interface SeenIssue {
 
 export type BountySourceType = "github" | "github_search" | "boss";
 
+// How trustworthy a bounty_amount is: platform-API-sourced amounts are
+// validated; regex extraction from issue text can misread currencies,
+// discussion mentions, or multiple amounts.
+export type BountyConfidence = "api" | "text_extract";
+
 export interface BountyIssue {
   source: BountySourceType;
   repo: string;
@@ -172,6 +177,8 @@ export interface BountyIssue {
   url: string;
   bounty_amount?: number;
   bounty_formatted?: string;
+  bounty_confidence?: BountyConfidence;
+  bounty_currency?: "USD" | "unknown";
   labels: string[];
   assignees: string[];
   body: string;


### PR DESCRIPTION
Fixes #14

## Summary

Bounty amounts mix two reliability tiers: Boss.dev amounts are platform-validated USD from the API, while GitHub and global-search amounts come from a `\$(\d[\d,]*)` regex over title/body that can misread non-USD currencies, discussion mentions, or multiple amounts.

- `BountyIssue` gains optional `bounty_confidence` (`"api" | "text_extract"`) and `bounty_currency` (`"USD" | "unknown"`)
- `boss.ts` tags `api`/`USD` always; `github.ts` and `github-search.ts` tag `text_extract`/`unknown` only when an amount was actually extracted (no metadata on amount-less issues)
- Telegram notifications mark unverified amounts with a tilde (`~$250`); API-confirmed and legacy entries render unchanged

Downstream consumers can now sort API-sourced amounts ahead of text-extracted ones. (Algora was removed earlier in this batch, so the original issue's Algora rows no longer apply.)

## Test plan

- [x] 6 new tests: boss api/USD tagging, github-search text_extract tagging + omission when no amount, telegram tilde for text_extract, no tilde for api, no tilde for legacy
- [x] Full suite 199 tests, tsc clean
- [ ] CI green