### PR TITLE
feat: heartbeat and failure alerting so the monitor cannot die silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ sources:
 | Field | Description |
 |---|---|
 | `polling_interval` | How often the background monitor checks for new issues, in minutes |
+| `seen_retention_days` | Days to keep seen.json entries before pruning on load (default `90`, `0` = never) |
+| `heartbeat_hours` | Hours between Telegram heartbeat messages (default `24`, `0` = disabled). Reports scans and queued bounties since the last heartbeat and flags failing or dry sources. A source failing 3 runs in a row also triggers an immediate alert |
 | `telegram.bot_token` | Token from @BotFather |
 | `telegram.chat_id` | Your Telegram chat ID (the setup wizard helps you find this) |
 | `sources.repos[].name` | GitHub repo in `owner/repo` format |

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { HealthStore, FAILURE_ALERT_THRESHOLD } from "./health.js";
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const TEST_DIR = "/tmp/bounty-hunter-test-health";
+const path = join(TEST_DIR, "health.json");
+
+describe("HealthStore", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe("failure streaks", () => {
+    it("requests an alert from the threshold onward until delivery is marked", () => {
+      const h = new HealthStore(path);
+      const results: boolean[] = [];
+      for (let i = 0; i < FAILURE_ALERT_THRESHOLD + 2; i++) {
+        results.push(h.recordSourceFailure("boss.dev"));
+      }
+      // Keeps requesting (retry) because no delivery was ever marked
+      expect(results).toEqual([false, false, true, true, true]);
+    });
+
+    it("stops requesting alerts once delivery is marked", () => {
+      const h = new HealthStore(path);
+      for (let i = 0; i < FAILURE_ALERT_THRESHOLD; i++) h.recordSourceFailure("boss.dev");
+      h.markFailureAlerted("boss.dev");
+      expect(h.recordSourceFailure("boss.dev")).toBe(false);
+      expect(h.recordSourceFailure("boss.dev")).toBe(false);
+    });
+
+    it("clears the delivered flag on success so the next streak alerts again", () => {
+      const h = new HealthStore(path);
+      for (let i = 0; i < FAILURE_ALERT_THRESHOLD; i++) h.recordSourceFailure("x");
+      h.markFailureAlerted("x");
+      h.recordSourceSuccess("x", 1);
+      const results: boolean[] = [];
+      for (let i = 0; i < FAILURE_ALERT_THRESHOLD; i++) {
+        results.push(h.recordSourceFailure("x"));
+      }
+      expect(results[FAILURE_ALERT_THRESHOLD - 1]).toBe(true);
+    });
+
+    it("resets the streak on success so a new streak can alert again", () => {
+      const h = new HealthStore(path);
+      for (let i = 0; i < FAILURE_ALERT_THRESHOLD; i++) h.recordSourceFailure("x");
+      h.recordSourceSuccess("x", 0);
+      const results: boolean[] = [];
+      for (let i = 0; i < FAILURE_ALERT_THRESHOLD; i++) {
+        results.push(h.recordSourceFailure("x"));
+      }
+      expect(results[FAILURE_ALERT_THRESHOLD - 1]).toBe(true);
+    });
+
+    it("tracks streaks per source independently", () => {
+      const h = new HealthStore(path);
+      h.recordSourceFailure("a");
+      h.recordSourceFailure("a");
+      expect(h.recordSourceFailure("b")).toBe(false);
+      expect(h.recordSourceFailure("a")).toBe(true);
+    });
+  });
+
+  describe("persistence", () => {
+    it("persists state across instances", () => {
+      const h1 = new HealthStore(path);
+      h1.recordSourceFailure("boss.dev");
+      h1.recordSourceFailure("boss.dev");
+      const h2 = new HealthStore(path);
+      expect(h2.recordSourceFailure("boss.dev")).toBe(true);
+    });
+
+    it("recovers from a corrupt file by resetting instead of crashing", () => {
+      writeFileSync(path, "not json");
+      const h = new HealthStore(path);
+      expect(h.recordSourceFailure("x")).toBe(false);
+    });
+
+    it("does not leave a temp file behind", () => {
+      const h = new HealthStore(path);
+      h.recordScan(1);
+      expect(existsSync(`${path}.tmp`)).toBe(false);
+    });
+  });
+
+  describe("heartbeat", () => {
+    it("is due on a fresh store", () => {
+      const h = new HealthStore(path);
+      expect(h.heartbeatDue(24)).toBe(true);
+    });
+
+    it("is never due when disabled with 0", () => {
+      const h = new HealthStore(path);
+      expect(h.heartbeatDue(0)).toBe(false);
+    });
+
+    it("is not due again immediately after marking sent", () => {
+      const h = new HealthStore(path);
+      h.markHeartbeatSent();
+      expect(h.heartbeatDue(24)).toBe(false);
+    });
+
+    it("stays due when the message was built but the send never confirmed", () => {
+      const h = new HealthStore(path);
+      h.buildHeartbeatMessage();
+      expect(h.heartbeatDue(24)).toBe(true);
+    });
+
+    it("becomes due once the interval elapses", () => {
+      const h = new HealthStore(path);
+      h.markHeartbeatSent();
+      const realNow = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(realNow + 25 * 60 * 60 * 1000);
+      expect(h.heartbeatDue(24)).toBe(true);
+    });
+
+    it("summarizes scans and queued counts; counters reset only on mark", () => {
+      const h = new HealthStore(path);
+      h.recordScan(2);
+      h.recordScan(0);
+      h.recordScan(3);
+      const msg = h.buildHeartbeatMessage();
+      expect(msg).toContain("3 scans");
+      expect(msg).toContain("5 bounties queued");
+      // Building is a pure read; counters survive a failed send
+      expect(h.buildHeartbeatMessage()).toContain("3 scans");
+      h.markHeartbeatSent();
+      const next = h.buildHeartbeatMessage();
+      expect(next).toContain("0 scans");
+      expect(next).toContain("0 bounties queued");
+    });
+
+    it("reports failing sources by name", () => {
+      const h = new HealthStore(path);
+      h.recordSourceSuccess("Expensify/App", 5);
+      h.recordSourceFailure("boss.dev");
+      const msg = h.buildHeartbeatMessage();
+      expect(msg).toContain("Failing: boss.dev");
+      expect(msg).toContain("1/2 OK");
+    });
+
+    it("flags sources that have not returned items for days", () => {
+      const realNow = Date.now();
+      vi.spyOn(Date, "now").mockReturnValue(realNow - 5 * 24 * 60 * 60 * 1000);
+      const h = new HealthStore(path);
+      h.recordSourceSuccess("github_search", 4); // had items, 5 days ago
+      vi.spyOn(Date, "now").mockReturnValue(realNow);
+      const msg = h.buildHeartbeatMessage();
+      expect(msg).toContain("No items for 3+ days: github_search");
+    });
+
+    it("does not flag a source that recently returned items", () => {
+      const h = new HealthStore(path);
+      h.recordSourceSuccess("github_search", 4);
+      const msg = h.buildHeartbeatMessage();
+      expect(msg).not.toContain("No items");
+    });
+  });
+});

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,172 @@
+import { readFileSync, writeFileSync, existsSync, renameSync } from "node:fs";
+
+// Consecutive failures of one source before an alert fires (once per streak)
+export const FAILURE_ALERT_THRESHOLD = 3;
+
+// A source with no items for this long gets flagged in the heartbeat
+const DRY_SOURCE_DAYS = 3;
+
+interface SourceHealth {
+  last_ok?: string; // last run that completed without an error
+  last_items?: string; // last run that returned at least one issue
+  consecutive_failures: number;
+  failure_alerted?: boolean; // an alert for the current streak was DELIVERED
+}
+
+interface HealthState {
+  last_heartbeat_at?: string;
+  scans_since_heartbeat: number;
+  queued_since_heartbeat: number;
+  sources: Record<string, SourceHealth>;
+}
+
+function emptyState(): HealthState {
+  return {
+    scans_since_heartbeat: 0,
+    queued_since_heartbeat: 0,
+    sources: {},
+  };
+}
+
+/**
+ * Persistent monitor self-health: scan counters, per-source success/failure
+ * streaks, and heartbeat bookkeeping. The monitor has died silently twice
+ * (disabled cron, dry sources); everything here exists so silence is loud.
+ */
+export class HealthStore {
+  private path: string;
+  private state: HealthState;
+
+  constructor(path: string) {
+    this.path = path;
+    this.state = this.load();
+  }
+
+  private load(): HealthState {
+    if (!existsSync(this.path)) return emptyState();
+    try {
+      const parsed = JSON.parse(readFileSync(this.path, "utf-8")) as HealthState;
+      return {
+        ...emptyState(),
+        ...parsed,
+        sources: parsed.sources ?? {},
+      };
+    } catch (err) {
+      // Health data is derived bookkeeping; losing it only resets counters.
+      // Warn loudly and start fresh rather than crashing the monitor.
+      console.error(
+        `HealthStore: ${this.path} is corrupt, resetting health state:`,
+        err instanceof Error ? err.message : err
+      );
+      return emptyState();
+    }
+  }
+
+  private save(): void {
+    // Best-effort, mirroring the load path: health is derived bookkeeping,
+    // and a disk hiccup here must never break bounty polling or notification
+    // (recordScan runs between "marked seen" and "notified", so a throw
+    // would permanently eat every bounty collected this run).
+    try {
+      // Write-then-rename so a crash mid-write can never truncate the live file
+      const tmp = `${this.path}.tmp`;
+      writeFileSync(tmp, JSON.stringify(this.state, null, 2));
+      renameSync(tmp, this.path);
+    } catch (err) {
+      console.error(
+        `HealthStore: failed to persist ${this.path} (health state may be stale):`,
+        err instanceof Error ? err.message : err
+      );
+    }
+  }
+
+  private source(name: string): SourceHealth {
+    if (!this.state.sources[name]) {
+      this.state.sources[name] = { consecutive_failures: 0 };
+    }
+    return this.state.sources[name];
+  }
+
+  /** Record a successful poll of one source. Resets its failure streak. */
+  recordSourceSuccess(name: string, fetchedCount: number): void {
+    const s = this.source(name);
+    s.last_ok = new Date(Date.now()).toISOString();
+    if (fetchedCount > 0) s.last_items = new Date(Date.now()).toISOString();
+    s.consecutive_failures = 0;
+    s.failure_alerted = false;
+    this.save();
+  }
+
+  /**
+   * Record a failed poll of one source. Returns true when the streak is at
+   * or past FAILURE_ALERT_THRESHOLD and no alert for this streak has been
+   * DELIVERED yet — the caller keeps retrying the alert each run until a
+   * send succeeds, then calls markFailureAlerted.
+   */
+  recordSourceFailure(name: string): boolean {
+    const s = this.source(name);
+    s.consecutive_failures++;
+    this.save();
+    return (
+      s.consecutive_failures >= FAILURE_ALERT_THRESHOLD && !s.failure_alerted
+    );
+  }
+
+  /** Call after a failure-streak alert was actually delivered. */
+  markFailureAlerted(name: string): void {
+    this.source(name).failure_alerted = true;
+    this.save();
+  }
+
+  /** Record one completed monitor run and how many issues it queued. */
+  recordScan(queuedCount: number): void {
+    this.state.scans_since_heartbeat++;
+    this.state.queued_since_heartbeat += queuedCount;
+    this.save();
+  }
+
+  /** True when the last heartbeat is older than the interval (0 = disabled). */
+  heartbeatDue(intervalHours: number): boolean {
+    if (intervalHours <= 0) return false;
+    if (!this.state.last_heartbeat_at) return true;
+    const elapsed = Date.now() - new Date(this.state.last_heartbeat_at).getTime();
+    return elapsed >= intervalHours * 60 * 60 * 1000;
+  }
+
+  /** Builds the heartbeat text. Pure read; call markHeartbeatSent after the
+   * message actually went out, so a failed send does not eat the heartbeat. */
+  buildHeartbeatMessage(): string {
+    const lines = [
+      `bounty-hunter alive: ${this.state.scans_since_heartbeat} scans, ` +
+        `${this.state.queued_since_heartbeat} bounties queued since last heartbeat.`,
+    ];
+    const names = Object.keys(this.state.sources);
+    if (names.length > 0) {
+      const failing = names.filter(
+        (n) => this.state.sources[n].consecutive_failures > 0
+      );
+      const dryCutoff = Date.now() - DRY_SOURCE_DAYS * 24 * 60 * 60 * 1000;
+      const dry = names.filter((n) => {
+        const s = this.state.sources[n];
+        if (s.consecutive_failures > 0) return false; // already listed as failing
+        const lastItems = s.last_items ? new Date(s.last_items).getTime() : 0;
+        return lastItems < dryCutoff;
+      });
+      const ok = names.length - failing.length - dry.length;
+      lines.push(`Sources: ${ok}/${names.length} OK.`);
+      if (failing.length > 0) lines.push(`Failing: ${failing.join(", ")}.`);
+      if (dry.length > 0) {
+        lines.push(`No items for ${DRY_SOURCE_DAYS}+ days: ${dry.join(", ")}.`);
+      }
+    }
+    return lines.join("\n");
+  }
+
+  /** Resets the per-period counters after a heartbeat was delivered. */
+  markHeartbeatSent(): void {
+    this.state.last_heartbeat_at = new Date(Date.now()).toISOString();
+    this.state.scans_since_heartbeat = 0;
+    this.state.queued_since_heartbeat = 0;
+    this.save();
+  }
+}

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -5,6 +5,7 @@ import { fetchRepoIssues, fetchIssueComments, fetchIssueMetadata } from "./githu
 import { fetchGlobalBounties } from "./github-search.js";
 import { fetchBossBounties, buildBossFilters } from "./boss.js";
 import { SeenStore, effectiveRetentionDays } from "./seen.js";
+import { HealthStore, FAILURE_ALERT_THRESHOLD } from "./health.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
 import { vetIssue } from "./vet.js";
 import type {
@@ -14,6 +15,7 @@ import type {
   RepoSource,
   VetResult,
   VettingConfig,
+  WatchlistConfig,
 } from "./types.js";
 
 export function applyPreFilter(issue: BountyIssue, filter: RepoSource["pre_filter"]): boolean {
@@ -139,6 +141,24 @@ export function shouldNotify(
   }
 }
 
+/**
+ * Best-effort Telegram alert: a failed alert send must never crash a run.
+ * Returns whether the alert was actually delivered so callers can retry
+ * next run instead of treating an attempt as delivery.
+ */
+async function sendAlert(
+  telegram: WatchlistConfig["telegram"],
+  text: string
+): Promise<boolean> {
+  try {
+    await sendTelegramMessage(telegram, `⚠️ ${text}`);
+    return true;
+  } catch (err) {
+    console.error("Failed to send alert:", err instanceof Error ? err.message : err);
+    return false;
+  }
+}
+
 export async function runMonitor(): Promise<void> {
   const config = loadConfig();
   const dataDir = getDataDir();
@@ -147,6 +167,7 @@ export async function runMonitor(): Promise<void> {
     join(dataDir, "seen.json"),
     effectiveRetentionDays(config.seen_retention_days, config.filters.max_age_days)
   );
+  const health = new HealthStore(join(dataDir, "health.json"));
   const vettingEnabled = config.vetting.enabled;
 
   const allNew: Array<{ issue: BountyIssue; vetResult?: VetResult }> = [];
@@ -195,8 +216,17 @@ export async function runMonitor(): Promise<void> {
         allNew.push({ issue, vetResult });
       }
       console.log(formatSourceSummary(repo.name, tally));
+      health.recordSourceSuccess(repo.name, tally.fetched);
     } catch (err) {
       console.error(`Error polling ${repo.name}:`, err);
+      if (health.recordSourceFailure(repo.name)) {
+        const delivered = await sendAlert(
+          config.telegram,
+          `bounty-hunter: source ${repo.name} has failed ${FAILURE_ALERT_THRESHOLD}+ runs in a row. ` +
+            `Last error: ${err instanceof Error ? err.message : err}`
+        );
+        if (delivered) health.markFailureAlerted(repo.name);
+      }
     }
   }
 
@@ -237,8 +267,17 @@ export async function runMonitor(): Promise<void> {
         allNew.push({ issue, vetResult });
       }
       console.log(formatSourceSummary("github_search", tally));
+      health.recordSourceSuccess("github_search", tally.fetched);
     } catch (err) {
       console.error("Error polling GitHub Global Search:", err);
+      if (health.recordSourceFailure("github_search")) {
+        const delivered = await sendAlert(
+          config.telegram,
+          `bounty-hunter: source github_search has failed ${FAILURE_ALERT_THRESHOLD}+ runs in a row. ` +
+            `Last error: ${err instanceof Error ? err.message : err}`
+        );
+        if (delivered) health.markFailureAlerted("github_search");
+      }
     }
   }
 
@@ -294,40 +333,75 @@ export async function runMonitor(): Promise<void> {
         allNew.push({ issue, vetResult });
       }
       console.log(formatSourceSummary("boss.dev", tally));
+      health.recordSourceSuccess("boss.dev", tally.fetched);
     } catch (err) {
       console.error("Error polling Boss.dev:", err);
+      if (health.recordSourceFailure("boss.dev")) {
+        const delivered = await sendAlert(
+          config.telegram,
+          `bounty-hunter: source boss.dev has failed ${FAILURE_ALERT_THRESHOLD}+ runs in a row. ` +
+            `Last error: ${err instanceof Error ? err.message : err}`
+        );
+        if (delivered) health.markFailureAlerted("boss.dev");
+      }
     }
   }
+
+  health.recordScan(allNew.length);
 
   // Notify
   if (allNew.length === 0) {
     console.log(`[${new Date().toISOString()}] No new bounties found.`);
-    return;
+  } else {
+    console.log(`[${new Date().toISOString()}] Found ${allNew.length} new bounties!`);
+
+    for (const { issue, vetResult } of allNew) {
+      if (!shouldNotify(vetResult, config.vetting.on_fail)) {
+        console.log(`  Skipped (vetting): ${issue.repo}#${issue.number} — ${vetResult?.summary}`);
+        continue;
+      }
+
+      try {
+        const message = formatBountyNotification(issue, vetResult);
+        await sendTelegramMessage(config.telegram, message);
+        console.log(`  Notified: ${issue.repo}#${issue.number}`);
+      } catch (err) {
+        console.error(`  Failed to notify ${issue.repo}#${issue.number}:`, err);
+      }
+    }
   }
 
-  console.log(`[${new Date().toISOString()}] Found ${allNew.length} new bounties!`);
-
-  for (const { issue, vetResult } of allNew) {
-    if (!shouldNotify(vetResult, config.vetting.on_fail)) {
-      console.log(`  Skipped (vetting): ${issue.repo}#${issue.number} — ${vetResult?.summary}`);
-      continue;
-    }
-
+  // Heartbeat: counters reset only after the send actually succeeds, so a
+  // Telegram outage delays the heartbeat instead of eating it
+  if (health.heartbeatDue(config.heartbeat_hours)) {
     try {
-      const message = formatBountyNotification(issue, vetResult);
-      await sendTelegramMessage(config.telegram, message);
-      console.log(`  Notified: ${issue.repo}#${issue.number}`);
+      await sendTelegramMessage(config.telegram, health.buildHeartbeatMessage());
     } catch (err) {
-      console.error(`  Failed to notify ${issue.repo}#${issue.number}:`, err);
+      console.error("Failed to send heartbeat:", err instanceof Error ? err.message : err);
+      return;
     }
+    // save() is best-effort, so marking cannot throw after a delivered send
+    health.markHeartbeatSent();
+    console.log("Heartbeat sent.");
   }
 }
 
 // Entry point when run directly
 const isMain = fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (isMain) {
-  runMonitor().catch((err) => {
+  runMonitor().catch(async (err) => {
     console.error(err);
+    // Best effort: tell Telegram the monitor itself crashed. Config load may
+    // be the very thing that failed, so guard everything.
+    try {
+      const config = loadConfig();
+      await sendAlert(
+        config.telegram,
+        `bounty-hunter: monitor run crashed: ${err instanceof Error ? err.message : err}`
+      );
+    } catch {
+      // No usable config; the console error above is all we can do
+    }
     process.exit(1);
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,8 @@ export const WatchlistConfigSchema = z.object({
   polling_interval: z.number(),
   // Days to keep seen.json entries before pruning on load (0 = never prune)
   seen_retention_days: z.number().int().nonnegative().default(90),
+  // Hours between Telegram heartbeat messages (0 = disabled)
+  heartbeat_hours: z.number().int().nonnegative().default(24),
   telegram: TelegramConfigSchema,
   sources: z.object({
     repos: z.array(RepoSourceSchema),

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -11,6 +11,13 @@ polling_interval: 15
 # re-notify while still inside the freshness window.
 seen_retention_days: 90
 
+# Hours between Telegram heartbeat messages (0 = disabled). The heartbeat
+# reports scans/bounties since the last one and flags failing or dry sources,
+# so the monitor can never die silently. Note: disabling it also disables the
+# periodic reminder about sources stuck in a failure streak; the one-time
+# streak alert still fires.
+heartbeat_hours: 24
+
 telegram:
   bot_token: "set-via-env"
   chat_id: "set-via-env"


### PR DESCRIPTION
Fixes #27

## Summary

The highest-value item from the audit: the monitor has died silently twice (auto-disabled cron, dry sources), so this adds the layer that makes silence loud.

- **`HealthStore`** (`~/.bounty-hunter/health.json`, atomic write-then-rename): per-source `last_ok` / `last_items` / `consecutive_failures`, scan and queued counters
- **Failure-streak alerts**: a source failing 3 runs in a row sends a Telegram alert with the last error. Delivery-tracked: the alert retries every run until a send actually succeeds (`failure_alerted` flag set only on confirmed delivery, cleared on source recovery)
- **Daily heartbeat** (`heartbeat_hours`, default 24, `0` = off): "alive, N scans, M bounties queued", plus failing sources by name and sources with no items for 3+ days. Two-phase send: counters reset only after the message is confirmed delivered, so a Telegram outage delays a heartbeat rather than eating it
- **Fatal-crash alert**: the entry-point catch makes a best-effort Telegram send, guarded for the config-load-is-what-failed case

## Review-loop hardening

The silent-failure pass found a Critical in the first draft: `HealthStore.save()` was unguarded and `recordScan` runs between "marked seen" and "notified", so a disk error in bookkeeping would have permanently eaten every bounty in the run. `save()` is now best-effort (stderr warning, stale counters at worst), matching the load path's corrupt-file-resets philosophy. Second pass confirmed convergence with zero remaining findings.

## Known gap

`runMonitor` itself still has no automated test (pre-existing: it does I/O through `loadConfig`/`getDataDir` with no injection; all 17 new tests cover `HealthStore` in isolation). Refactoring for injectability is out of scope here.

## Test plan

- [x] 17 health tests: retry-until-delivery alert sequence, stop-after-delivery, flag-cleared-on-recovery, per-source independence, heartbeat due/disabled/elapsed, build-is-pure / reset-on-mark, dry-source flagging, corrupt-file reset, atomic persistence
- [x] Full suite 216 tests, tsc clean
- [ ] CI green