### PR TITLE
fix: harden the launchd installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ On macOS, it runs as a launchd agent that fires every N minutes (matching your `
 node dist/install-launchd.js install
 ```
 
-This creates a launchd plist at `~/Library/LaunchAgents/com.bounty-hunter.monitor.plist`, loads it immediately, and starts polling. The monitor runs at login and on the configured interval.
+This creates a launchd plist at `~/Library/LaunchAgents/com.bounty-hunter.monitor.plist`, loads it immediately, verifies the job is actually listed, and starts polling. The monitor runs at login and on the configured interval.
+
+The installer validates everything up front and refuses to install when the build is missing, the watchlist config is absent or invalid, or the Telegram credentials are placeholders. launchd jobs do not inherit your shell environment, so the real `bot_token` and `chat_id` must live in `~/.bounty-hunter/watchlist.yml` (set the file to `chmod 600`). The plist pins the absolute Node binary that ran the installer, so version-manager shims and PATH differences cannot break the scheduled runs.
 
 ### Uninstall the Monitor
 

--- a/src/install-launchd.test.ts
+++ b/src/install-launchd.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { generatePlist } from "./install-launchd.js";
-import { mkdirSync, rmSync } from "node:fs";
+import { generatePlist, validateInstallPreconditions } from "./install-launchd.js";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 const TEST_HOME = "/tmp/bounty-hunter-test-launchd";
 
@@ -43,5 +44,107 @@ describe("generatePlist", () => {
     expect(plist).toContain("&gt;");
     expect(plist).not.toContain("<special>");
     expect(plist).not.toContain("&chars>");
+  });
+
+  it("uses the absolute node binary instead of a bare PATH lookup", () => {
+    const plist = generatePlist("/path/monitor.js", 300);
+    expect(plist).toContain(`<string>${process.execPath}</string>`);
+    expect(plist).not.toContain("<string>node</string>");
+  });
+
+  it("accepts an explicit node path", () => {
+    const plist = generatePlist("/path/monitor.js", 300, "/custom/node");
+    expect(plist).toContain("<string>/custom/node</string>");
+  });
+});
+
+describe("validateInstallPreconditions", () => {
+  let originalHome: string | undefined;
+  const scriptPath = join(TEST_HOME, "monitor.js");
+
+  function writeConfig(botToken: string, chatId: string): void {
+    const dataDir = join(TEST_HOME, ".bounty-hunter");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(
+      join(dataDir, "watchlist.yml"),
+      `
+polling_interval: 5
+telegram:
+  bot_token: "${botToken}"
+  chat_id: "${chatId}"
+sources:
+  repos: []
+`
+    );
+  }
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    process.env.HOME = TEST_HOME;
+    mkdirSync(TEST_HOME, { recursive: true });
+    writeFileSync(scriptPath, "// compiled monitor");
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  it("passes with a real config and existing script", () => {
+    writeConfig("123456:real-token", "987654");
+    const config = validateInstallPreconditions(scriptPath);
+    expect(config.polling_interval).toBe(5);
+  });
+
+  it("rejects a missing monitor script with build guidance", () => {
+    writeConfig("123456:real-token", "987654");
+    expect(() => validateInstallPreconditions(join(TEST_HOME, "nope.js"))).toThrow(
+      /npm run build/
+    );
+  });
+
+  it("rejects a missing config before touching anything", () => {
+    expect(() => validateInstallPreconditions(scriptPath)).toThrow(/watchlist/);
+  });
+
+  it("rejects placeholder telegram credentials", () => {
+    writeConfig("set-via-env", "set-via-env");
+    expect(() => validateInstallPreconditions(scriptPath)).toThrow(
+      /do not inherit/
+    );
+  });
+
+  it("rejects empty telegram credentials", () => {
+    writeConfig("", "987654");
+    expect(() => validateInstallPreconditions(scriptPath)).toThrow(
+      /do not inherit/
+    );
+  });
+
+  it("rejects placeholder YAML even when TELEGRAM_* env vars are exported", () => {
+    // The installer's shell env never reaches the launchd job, so exported
+    // tokens must not mask a placeholder config (loadConfig overlays them)
+    writeConfig("set-via-env", "set-via-env");
+    const prevToken = process.env.TELEGRAM_BOT_TOKEN;
+    const prevChat = process.env.TELEGRAM_CHAT_ID;
+    process.env.TELEGRAM_BOT_TOKEN = "123456:real-token-from-shell";
+    process.env.TELEGRAM_CHAT_ID = "987654";
+    try {
+      expect(() => validateInstallPreconditions(scriptPath)).toThrow(
+        /do not inherit/
+      );
+    } finally {
+      if (prevToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN;
+      else process.env.TELEGRAM_BOT_TOKEN = prevToken;
+      if (prevChat === undefined) delete process.env.TELEGRAM_CHAT_ID;
+      else process.env.TELEGRAM_CHAT_ID = prevChat;
+    }
+  });
+
+  it("rejects whitespace-only credentials", () => {
+    writeConfig("   ", "987654");
+    expect(() => validateInstallPreconditions(scriptPath)).toThrow(
+      /do not inherit/
+    );
   });
 });

--- a/src/install-launchd.ts
+++ b/src/install-launchd.ts
@@ -1,9 +1,11 @@
-import { writeFileSync, existsSync, mkdirSync, unlinkSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { writeFileSync, existsSync, mkdirSync, unlinkSync, readFileSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
 import { execFileSync } from "node:child_process";
-import { loadConfig, getDataDir } from "./config.js";
+import { parse } from "yaml";
+import { loadConfig, getDataDir, getConfigPath } from "./config.js";
+import type { WatchlistConfig } from "./types.js";
 
 const PLIST_NAME = "com.bounty-hunter.monitor";
 
@@ -19,7 +21,11 @@ function escapeXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
-export function generatePlist(monitorScriptPath: string, intervalSeconds: number): string {
+export function generatePlist(
+  monitorScriptPath: string,
+  intervalSeconds: number,
+  nodePath: string = process.execPath
+): string {
   const logPath = join(getDataDir(), "monitor.log");
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -30,7 +36,7 @@ export function generatePlist(monitorScriptPath: string, intervalSeconds: number
     <string>${PLIST_NAME}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>node</string>
+        <string>${escapeXml(nodePath)}</string>
         <string>${escapeXml(monitorScriptPath)}</string>
     </array>
     <key>StartInterval</key>
@@ -50,8 +56,60 @@ export function generatePlist(monitorScriptPath: string, intervalSeconds: number
 </plist>`;
 }
 
+/**
+ * Validates everything the launchd job needs BEFORE touching LaunchAgents,
+ * so a broken install fails with a clear message instead of half-applied
+ * state. Returns the loaded config on success.
+ */
+export function validateInstallPreconditions(
+  monitorScriptPath: string
+): WatchlistConfig {
+  if (!existsSync(monitorScriptPath)) {
+    throw new Error(
+      `Monitor script not found at ${monitorScriptPath}. Run "npm run build" first.`
+    );
+  }
+
+  let config: WatchlistConfig;
+  try {
+    config = loadConfig();
+  } catch (err) {
+    throw new Error(
+      `Cannot install: watchlist config is missing or invalid ` +
+        `(${err instanceof Error ? err.message : err}). ` +
+        `Create ~/.bounty-hunter/watchlist.yml before installing.`
+    );
+  }
+
+  // launchd jobs do not inherit your shell environment, so placeholders in
+  // the YAML mean the monitor would run without Telegram credentials and
+  // every notification would silently fail. Validate the RAW on-disk YAML:
+  // loadConfig overlays TELEGRAM_* env vars from the installer's shell,
+  // which the scheduled job will never see, so the overlaid values would
+  // mask exactly the misconfiguration this check exists to catch.
+  const rawYaml = parse(readFileSync(getConfigPath(), "utf-8")) as {
+    telegram?: { bot_token?: unknown; chat_id?: unknown };
+  };
+  const placeholders = ["", "set-via-env"];
+  const onDisk = [rawYaml.telegram?.bot_token, rawYaml.telegram?.chat_id];
+  if (
+    onDisk.some(
+      (v) => typeof v !== "string" || placeholders.includes(v.trim())
+    )
+  ) {
+    throw new Error(
+      "Telegram credentials in watchlist.yml are missing or placeholders. " +
+        "launchd jobs do not inherit your shell environment (TELEGRAM_* env " +
+        "vars will not reach the scheduled job), so put the real bot_token " +
+        "and chat_id in ~/.bounty-hunter/watchlist.yml (chmod 600) before installing."
+    );
+  }
+
+  return config;
+}
+
 export function installLaunchd(monitorScriptPath: string): void {
-  const config = loadConfig();
+  const config = validateInstallPreconditions(monitorScriptPath);
   const interval = (config.polling_interval ?? 5) * 60;
   const plistDir = getPlistDir();
   const plistPath = getPlistPath();
@@ -65,6 +123,16 @@ export function installLaunchd(monitorScriptPath: string): void {
     execFileSync("launchctl", ["unload", plistPath], { stdio: "ignore" });
   } catch {}
   execFileSync("launchctl", ["load", plistPath]);
+
+  // launchctl load can exit 0 without the job sticking; verify it is listed
+  try {
+    execFileSync("launchctl", ["list", PLIST_NAME], { stdio: "ignore" });
+  } catch {
+    throw new Error(
+      `launchctl load ran but ${PLIST_NAME} is not in launchctl list. ` +
+        `Inspect the plist at ${plistPath} and try "launchctl load ${plistPath}" manually.`
+    );
+  }
 
   console.log(`Installed and loaded ${PLIST_NAME}`);
   console.log(`Polling every ${config.polling_interval} minutes`);
@@ -87,7 +155,8 @@ const isMain = fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (isMain) {
   const action = process.argv[2];
   if (action === "install") {
-    const scriptPath = join(process.cwd(), "dist", "monitor.js");
+    // monitor.js sits next to this compiled file in dist/, independent of cwd
+    const scriptPath = join(dirname(fileURLToPath(import.meta.url)), "monitor.js");
     installLaunchd(scriptPath);
   } else if (action === "uninstall") {
     uninstallLaunchd();


### PR DESCRIPTION
Fixes #32

## Summary

The launchd installer is about to become the primary deployment path (the GH Actions schedule goes away in the next PR), so its gaps get fixed first:

- **Absolute Node binary**: the plist pins `process.execPath` instead of a bare `node` + hardcoded PATH, so nvm/asdf shims and PATH differences can't break scheduled runs (overridable third param on `generatePlist`)
- **cwd-independent script path**: the entry point resolves `monitor.js` next to the compiled module in `dist/`, not under whatever directory the installer happened to run from
- **Up-front preconditions** (`validateInstallPreconditions`, runs before touching `~/Library/LaunchAgents`): build output must exist (with `npm run build` guidance), config must load, and the **on-disk** Telegram credentials must not be empty/whitespace/`set-via-env`. The check parses the raw YAML deliberately: review caught that `loadConfig` overlays `TELEGRAM_*` env vars from the installer's shell, which the launchd job never inherits, so exported tokens would have masked exactly the silent-notification-failure this check exists to prevent
- **Load verification**: after `launchctl load`, the job must appear in `launchctl list`, otherwise the install fails with manual-recovery guidance

## Test plan

- [x] 10 new tests: execPath pinning + override, all precondition rejections (missing script, missing config, placeholder/empty/whitespace credentials), and the env-override regression case (exported TELEGRAM_* vars + placeholder YAML must still throw)
- [x] Full suite 225 tests, tsc clean
- [ ] CI green