### PR TITLE
chore: drop the GitHub Actions schedule; launchd is the only scheduler

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -1,10 +1,12 @@
+# Manual smoke test only. Scheduled monitoring runs via launchd on a local
+# Mac (see README "Background Monitor"); a GitHub Actions cron is the wrong
+# host because GitHub auto-disables schedules after 60 days of repo
+# inactivity, which silently killed monitoring from 2026-04-23 onward, and
+# the run below uses the example watchlist rather than a real one.
 name: Bounty Monitor
 
 on:
-  schedule:
-    # Every 15 minutes
-    - cron: "*/15 * * * *"
-  workflow_dispatch: # Allow manual triggers
+  workflow_dispatch: # Manual smoke-test runs only
 
 jobs:
   monitor:

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ bounty-hunter config
 
 The background monitor is a standalone Node.js script that runs without AI. It polls GitHub and Boss.dev on a timer, checks for new issues against the seen store, and sends Telegram notifications for anything new.
 
-On macOS, it runs as a launchd agent that fires every N minutes (matching your `polling_interval` setting).
+On macOS, it runs as a launchd agent that fires every N minutes (matching your `polling_interval` setting). launchd is the only supported scheduler: a GitHub Actions cron was tried and abandoned because GitHub silently disables scheduled workflows after 60 days of repo inactivity, which is fatal for a monitor that should outlive active development (the repo's `Bounty Monitor` workflow remains as a manual smoke test only).
 
 ### Install the Monitor
 


### PR DESCRIPTION
Fixes #28

## Summary

Closes out the scheduling migration. The cron trigger is removed from `monitor.yml`; the workflow stays dispatch-only as a manual smoke test (its example-config + repo-secrets steps still work standalone). A header comment records why the schedule is gone: GitHub auto-disables scheduled workflows after 60 days of repo inactivity, which is what silently killed monitoring on 2026-04-23, and the cloud run always used `watchlist.example.yml` instead of a real config anyway.

The README now states launchd is the only supported scheduler. The launchd installer was hardened in the previous PR (preconditions, absolute node path, load verification), and the heartbeat from the alerting PR means a future silent death gets surfaced within a day.

## Test plan

- [x] Full suite 225 tests (no code paths reference the schedule trigger)
- [x] Dispatch-only workflow YAML coherent; docs cross-references verified by review
- [ ] CI green