### PR TITLE
feat: per-source filter overrides for Boss.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ sources:
 | `sources.repos[].filters` | Per-repo overrides of the global `filters` block (`max_age_days`, `skip_assigned`, `claimed_labels`, `max_comment_count`). Needed for repos like Expensify/App that auto-assign and bot-comment on every issue, which the global defaults would drop entirely |
 | `sources.boss.enabled` | Whether to poll Boss.dev for bounties (default `true`; currently the most reliable source) |
 | `sources.boss.min_bounty` | Minimum bounty amount in USD (0 = no minimum) |
+| `sources.boss.filters` | Per-source overrides of the global `filters` block. Boss's catalog is mostly standing bounties, so the example sets `max_age_days: 0` here; without it the source never notifies (seen.json dedup still makes each standing bounty surface exactly once) |
 | `sources.github_search.enabled` | Whether to search all of GitHub for bounty-labeled issues (default `false`) |
 | `sources.github_search.min_stars` | Only include repos with at least N stars (default `200`; bounty-farm repos dominate below that) |
 | `sources.github_search.repos_exclude` | Blocklist of `owner/repo` to always skip |

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -123,6 +123,43 @@ sources:
     expect(config.filters.max_comment_count).toBe(5);
     expect(config.filters.claimed_labels).toContain("Reviewing");
   });
+
+  it("accepts per-source filter overrides on the boss block", () => {
+    const yml = `
+polling_interval: 5
+telegram:
+  bot_token: "test-token"
+  chat_id: "12345"
+sources:
+  repos: []
+  boss:
+    enabled: true
+    min_bounty: 50
+    filters:
+      max_age_days: 0
+`;
+    writeFileSync(join(TEST_DIR, "watchlist.yml"), yml);
+    const config = loadConfig(join(TEST_DIR, "watchlist.yml"));
+    expect(config.sources.boss?.filters?.max_age_days).toBe(0);
+    // Only the overridden key is present; merging happens at poll time
+    expect(config.sources.boss?.filters?.skip_assigned).toBeUndefined();
+  });
+
+  it("boss block without filters has no override", () => {
+    const yml = `
+polling_interval: 5
+telegram:
+  bot_token: "test-token"
+  chat_id: "12345"
+sources:
+  repos: []
+  boss:
+    enabled: true
+`;
+    writeFileSync(join(TEST_DIR, "watchlist.yml"), yml);
+    const config = loadConfig(join(TEST_DIR, "watchlist.yml"));
+    expect(config.sources.boss?.filters).toBeUndefined();
+  });
 });
 
 describe("vetting config defaults", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,7 @@ async function main() {
 
       // Poll Boss.dev
       if (config.sources.boss?.enabled) {
+        const bossFilters = resolveRepoFilters(config.filters, config.sources.boss.filters);
         try {
           const bounties = await fetchBossBounties(buildBossFilters(config.sources.boss));
           for (const issue of bounties) {
@@ -131,7 +132,7 @@ async function main() {
               );
             }
 
-            if (!applyFreshnessFilter(issue, config.filters)) continue;
+            if (!applyFreshnessFilter(issue, bossFilters)) continue;
 
             let vetResult: VetResult | undefined;
             if (vettingEnabled) {

--- a/src/monitor.ts
+++ b/src/monitor.ts
@@ -285,6 +285,7 @@ export async function runMonitor(): Promise<void> {
   if (config.sources.boss?.enabled) {
     try {
       const tally = newDropTally();
+      const bossFilters = resolveRepoFilters(config.filters, config.sources.boss.filters);
       const bounties = await fetchBossBounties(buildBossFilters(config.sources.boss));
       tally.fetched = bounties.length;
       for (const issue of bounties) {
@@ -308,7 +309,7 @@ export async function runMonitor(): Promise<void> {
           );
         }
 
-        const dropReason = freshnessDropReason(issue, config.filters);
+        const dropReason = freshnessDropReason(issue, bossFilters);
         if (dropReason !== null) {
           tally[dropReason]++;
           continue;

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,11 @@ export const BossSourceSchema = z.object({
   // Enabled by default: Boss.dev is currently the most reliable bounty source
   enabled: z.boolean().default(true),
   min_bounty: z.number().default(0),
+  // Per-source overrides of the global filters block. Boss's catalog is
+  // mostly standing bounties older than any reasonable max_age_days, so
+  // without max_age_days: 0 here the source never notifies at all (seen.json
+  // still dedups, so each standing bounty surfaces exactly once).
+  filters: FiltersOverrideSchema.optional(),
 });
 
 const TelegramConfigSchema = z.object({

--- a/watchlist.example.yml
+++ b/watchlist.example.yml
@@ -85,6 +85,12 @@ sources:
   boss:
     enabled: true              # Set to false to disable Boss.dev polling
     min_bounty: 50             # Minimum bounty amount in USD (0 = no minimum)
+    # Boss's catalog is mostly standing bounties older than the global
+    # max_age_days, so without this override the source never notifies.
+    # seen.json still dedups, so each standing bounty surfaces exactly once
+    # (expect a one-time burst on the first run).
+    filters:
+      max_age_days: 0
 
   # GitHub Global Label Search — searches ALL of GitHub for bounty-labeled issues
   # This discovers bounties beyond your watched repos. Defaults are


### PR DESCRIPTION
Fixes #47

## Summary

First production run data: boss.dev fetched 11, queued 0, all dropped `too_old`. Boss's catalog is standing bounties (months to years old), so with real creation dates from the fixed enrichment, the global `max_age_days: 7` permanently silences the source.

This reuses the per-repo override machinery from the Expensify fix verbatim: `BossSourceSchema` gains optional `filters` (same `FiltersOverrideSchema`), and both boss loops resolve it against the globals via `resolveRepoFilters`. The example config sets `max_age_days: 0` for boss, documented with the expected behavior: each standing bounty notifies exactly once (seen.json dedup), as a one-time burst on the first run after enabling.

github_search and repo paths are untouched.

## Test plan

- [x] 2 new config tests: boss `filters` parses (partial, only overridden keys present), absent block means no override
- [x] Full suite 227 tests, tsc clean
- [ ] CI green