### PR TITLE
Use a durable Node path in the launchd plist + add doctor health check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ src/
   telegram.ts            Telegram Bot API client (send messages, get updates, vet-enriched notifications)
   vet.ts                 Issue vetting — rule-based checks (access, competition, bounty, platform)
   monitor.ts             Background polling loop + pre-filter + vetting integration
-  index.ts               CLI entry point (scan, notify, post-comment, seen, config)
+  index.ts               CLI entry point (scan, notify, post-comment, seen, config, doctor)
   install-launchd.ts     macOS launchd plist generator and installer
 
 commands/                Claude Code slash commands

--- a/README.md
+++ b/README.md
@@ -300,6 +300,12 @@ bounty-hunter seen --add owner/repo#123
 
 # Output current watchlist config as JSON
 bounty-hunter config
+
+# Health-check the installed launchd job (verifies the plist's Node binary
+# and monitor script still exist and the job is loaded). Exits non-zero on
+# any failure, so it is safe to wire into a cron/watchdog. Add --json for
+# machine-readable output.
+bounty-hunter doctor
 ```
 
 ## Background Monitor
@@ -316,7 +322,13 @@ node dist/install-launchd.js install
 
 This creates a launchd plist at `~/Library/LaunchAgents/com.bounty-hunter.monitor.plist`, loads it immediately, verifies the job is actually listed, and starts polling. The monitor runs at login and on the configured interval.
 
-The installer validates everything up front and refuses to install when the build is missing, the watchlist config is absent or invalid, or the Telegram credentials are placeholders. launchd jobs do not inherit your shell environment, so the real `bot_token` and `chat_id` must live in `~/.bounty-hunter/watchlist.yml` (set the file to `chmod 600`). The plist pins the absolute Node binary that ran the installer, so version-manager shims and PATH differences cannot break the scheduled runs.
+The installer validates everything up front and refuses to install when the build is missing, the watchlist config is absent or invalid, or the Telegram credentials are placeholders. launchd jobs do not inherit your shell environment, so the real `bot_token` and `chat_id` must live in `~/.bounty-hunter/watchlist.yml` (set the file to `chmod 600`).
+
+The plist pins an absolute Node binary (not a bare `node` PATH lookup), so version-manager shims and PATH differences cannot break the scheduled runs. When the installer's `node` came from Homebrew, it deliberately uses the stable `/opt/homebrew/bin/node` (or `/usr/local/bin/node`) symlink rather than the version-pinned `.../Cellar/node/<version>/bin/node` path that `process.execPath` resolves to. Pinning the Cellar path would be a silent-death trap: the next `brew upgrade node` deletes that directory, launchd can never spawn the job again, and the in-process heartbeat never fires. If you install with a non-Homebrew Node (nvm, asdf, a system build), that absolute path is used as-is, so re-run `install` after switching Node managers.
+
+### Health check
+
+Run `bounty-hunter doctor` (or `node dist/install-launchd.js doctor`) to confirm the job is still viable: it checks that the plist exists, that the Node binary and monitor script paths inside it still resolve, and that the job is loaded in `launchctl list`. It exits non-zero on any failure so you can wire it into an external watchdog. If a past `brew upgrade node` broke an install pinned to an old Cellar path, the `node-path` check fails with a re-install hint.
 
 ### Uninstall the Monitor
 
@@ -390,7 +402,7 @@ bounty-hunter/
 │   ├── github.ts              # GitHub issue fetcher (wraps gh CLI via execFileSync)
 │   ├── telegram.ts            # Telegram Bot API (send messages, get updates)
 │   ├── monitor.ts             # Background polling loop + pre-filter logic
-│   ├── index.ts               # CLI entry point (scan, notify, post-comment, seen, config)
+│   ├── index.ts               # CLI entry point (scan, notify, post-comment, seen, config, doctor)
 │   └── install-launchd.ts     # macOS launchd plist generator and installer
 ├── commands/
 │   ├── hunt.md                # /hunt — scan for bounties

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { SeenStore, effectiveRetentionDays } from "./seen.js";
 import { sendTelegramMessage, formatBountyNotification } from "./telegram.js";
 import { applyPreFilter, applyFreshnessFilter, resolveRepoFilters } from "./monitor.js";
 import { vetIssue } from "./vet.js";
+import { doctor } from "./install-launchd.js";
 import { join } from "node:path";
 import { execFileSync } from "node:child_process";
 import type { BountyIssue, VetResult } from "./types.js";
@@ -238,8 +239,20 @@ async function main() {
       break;
     }
 
+    case "doctor": {
+      const report = doctor();
+      if (flags) {
+        console.log(JSON.stringify(report, null, 2));
+      } else {
+        for (const c of report.checks) {
+          console.log(`${c.ok ? "✅" : "❌"} ${c.name}: ${c.detail}`);
+        }
+      }
+      process.exit(report.ok ? 0 : 1);
+    }
+
     default:
-      console.log("Usage: bounty-hunter <scan|notify|post-comment|seen|config> [--json]");
+      console.log("Usage: bounty-hunter <scan|notify|post-comment|seen|config|doctor> [--json]");
   }
 }
 

--- a/src/install-launchd.test.ts
+++ b/src/install-launchd.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { generatePlist, validateInstallPreconditions } from "./install-launchd.js";
+import {
+  generatePlist,
+  validateInstallPreconditions,
+  resolveDurableNodePath,
+  extractProgramArguments,
+  doctor,
+} from "./install-launchd.js";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -46,15 +52,127 @@ describe("generatePlist", () => {
     expect(plist).not.toContain("&chars>");
   });
 
-  it("uses the absolute node binary instead of a bare PATH lookup", () => {
+  it("uses a durable absolute node binary instead of a bare PATH lookup", () => {
     const plist = generatePlist("/path/monitor.js", 300);
-    expect(plist).toContain(`<string>${process.execPath}</string>`);
+    expect(plist).toContain(`<string>${resolveDurableNodePath()}</string>`);
     expect(plist).not.toContain("<string>node</string>");
+  });
+
+  it("does not embed a version-pinned Homebrew Cellar node path by default", () => {
+    // The CRITICAL finding: pinning /opt/homebrew/Cellar/node/<version>/bin/node
+    // means `brew upgrade node` silently kills the launchd job forever. When the
+    // stable brew symlink exists, the default must not point inside Cellar.
+    const durable = resolveDurableNodePath();
+    if (!durable.includes("/Cellar/")) {
+      const plist = generatePlist("/path/monitor.js", 300);
+      expect(plist).not.toContain("/Cellar/");
+    }
   });
 
   it("accepts an explicit node path", () => {
     const plist = generatePlist("/path/monitor.js", 300, "/custom/node");
     expect(plist).toContain("<string>/custom/node</string>");
+  });
+});
+
+describe("resolveDurableNodePath", () => {
+  it("returns a non-Homebrew path unchanged", () => {
+    expect(resolveDurableNodePath("/usr/bin/node")).toBe("/usr/bin/node");
+    expect(resolveDurableNodePath("/some/nvm/versions/node/v22/bin/node")).toBe(
+      "/some/nvm/versions/node/v22/bin/node"
+    );
+  });
+
+  it("maps a Homebrew Cellar path to the stable symlink when it exists", () => {
+    const prefix = "/tmp/bounty-hunter-durable-node";
+    mkdirSync(join(prefix, "bin"), { recursive: true });
+    writeFileSync(join(prefix, "bin", "node"), "// stable node symlink target");
+    try {
+      const cellar = `${prefix}/Cellar/node/26.0.0/bin/node`;
+      expect(resolveDurableNodePath(cellar)).toBe(`${prefix}/bin/node`);
+    } finally {
+      rmSync(prefix, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the Cellar path when no stable symlink exists", () => {
+    const cellar = "/tmp/bounty-hunter-no-symlink/Cellar/node/26.0.0/bin/node";
+    expect(resolveDurableNodePath(cellar)).toBe(cellar);
+  });
+});
+
+describe("extractProgramArguments", () => {
+  it("parses node path and script path out of a generated plist", () => {
+    const plist = generatePlist("/data/monitor.js", 300, "/opt/homebrew/bin/node");
+    expect(extractProgramArguments(plist)).toEqual([
+      "/opt/homebrew/bin/node",
+      "/data/monitor.js",
+    ]);
+  });
+
+  it("unescapes XML entities in extracted paths", () => {
+    const plist = generatePlist("/path/with&<>chars.js", 300, "/opt/node");
+    expect(extractProgramArguments(plist)).toEqual([
+      "/opt/node",
+      "/path/with&<>chars.js",
+    ]);
+  });
+
+  it("returns [] when ProgramArguments is absent", () => {
+    expect(extractProgramArguments("<plist><dict></dict></plist>")).toEqual([]);
+  });
+});
+
+describe("doctor", () => {
+  let originalHome: string | undefined;
+  const HOME = "/tmp/bounty-hunter-doctor-test";
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    process.env.HOME = HOME;
+    rmSync(HOME, { recursive: true, force: true });
+    mkdirSync(HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(HOME, { recursive: true, force: true });
+  });
+
+  it("reports the plist as missing when nothing is installed", () => {
+    const report = doctor();
+    expect(report.ok).toBe(false);
+    const plistCheck = report.checks.find((c) => c.name === "plist");
+    expect(plistCheck?.ok).toBe(false);
+  });
+
+  it("flags a node path that no longer exists (the brew-upgrade death)", () => {
+    const plistDir = join(HOME, "Library", "LaunchAgents");
+    mkdirSync(plistDir, { recursive: true });
+    // Simulate an old install pinned to a now-deleted Cellar version.
+    const plist = generatePlist(
+      "/does/not/exist/monitor.js",
+      300,
+      "/opt/homebrew/Cellar/node/1.0.0/bin/node"
+    );
+    writeFileSync(join(plistDir, "com.bounty-hunter.monitor.plist"), plist);
+
+    const report = doctor();
+    expect(report.ok).toBe(false);
+    const nodeCheck = report.checks.find((c) => c.name === "node-path");
+    expect(nodeCheck?.ok).toBe(false);
+    expect(nodeCheck?.detail).toMatch(/brew upgrade node/);
+  });
+
+  it("passes the node-path check when the plist points at a live binary", () => {
+    const plistDir = join(HOME, "Library", "LaunchAgents");
+    mkdirSync(plistDir, { recursive: true });
+    const plist = generatePlist("/does/not/exist/monitor.js", 300, process.execPath);
+    writeFileSync(join(plistDir, "com.bounty-hunter.monitor.plist"), plist);
+
+    const report = doctor();
+    const nodeCheck = report.checks.find((c) => c.name === "node-path");
+    expect(nodeCheck?.ok).toBe(true);
   });
 });
 

--- a/src/install-launchd.ts
+++ b/src/install-launchd.ts
@@ -21,10 +21,38 @@ function escapeXml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
+function unescapeXml(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * Resolve a Node binary path that survives `brew upgrade node`.
+ *
+ * `process.execPath` resolves symlinks, so under Homebrew it is the
+ * version-pinned Cellar path (e.g. /opt/homebrew/Cellar/node/26.0.0/bin/node).
+ * Pinning that into the plist is a silent-death trap: the next `brew upgrade
+ * node` deletes that directory and launchd can never spawn the job again.
+ * When execPath is under a Homebrew Cellar, prefer the stable
+ * `<brew-prefix>/bin/node` symlink (which Homebrew re-points on every upgrade)
+ * if it exists; otherwise fall back to execPath unchanged.
+ */
+export function resolveDurableNodePath(execPath: string = process.execPath): string {
+  const marker = "/Cellar/";
+  const idx = execPath.indexOf(marker);
+  if (idx === -1) return execPath;
+  const brewPrefix = execPath.slice(0, idx); // e.g. /opt/homebrew or /usr/local
+  const stable = join(brewPrefix, "bin", "node");
+  return existsSync(stable) ? stable : execPath;
+}
+
 export function generatePlist(
   monitorScriptPath: string,
   intervalSeconds: number,
-  nodePath: string = process.execPath
+  nodePath: string = resolveDurableNodePath()
 ): string {
   const logPath = join(getDataDir(), "monitor.log");
   return `<?xml version="1.0" encoding="UTF-8"?>
@@ -139,6 +167,92 @@ export function installLaunchd(monitorScriptPath: string): void {
   console.log(`Logs: ${join(getDataDir(), "monitor.log")}`);
 }
 
+/**
+ * Extract the ProgramArguments array (argv) from a generated plist. Pure so it
+ * can be unit-tested without a real LaunchAgents file. Returns [] if the key or
+ * array is absent.
+ */
+export function extractProgramArguments(plistXml: string): string[] {
+  const keyIdx = plistXml.indexOf("<key>ProgramArguments</key>");
+  if (keyIdx === -1) return [];
+  const arrayStart = plistXml.indexOf("<array>", keyIdx);
+  const arrayEnd = plistXml.indexOf("</array>", arrayStart);
+  if (arrayStart === -1 || arrayEnd === -1) return [];
+  const block = plistXml.slice(arrayStart, arrayEnd);
+  return [...block.matchAll(/<string>([\s\S]*?)<\/string>/g)].map((m) =>
+    unescapeXml(m[1])
+  );
+}
+
+export interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface DoctorReport {
+  ok: boolean;
+  checks: DoctorCheck[];
+}
+
+/**
+ * Health check for the installed launchd job. The CRITICAL failure this exists
+ * to catch: the plist's Node binary path no longer exists (e.g. after
+ * `brew upgrade node` on an old install that pinned a Cellar path), so launchd
+ * fails to spawn the job forever and the in-process heartbeat can never fire.
+ */
+export function doctor(): DoctorReport {
+  const checks: DoctorCheck[] = [];
+  const plistPath = getPlistPath();
+  const plistExists = existsSync(plistPath);
+  checks.push({
+    name: "plist",
+    ok: plistExists,
+    detail: plistExists
+      ? `present: ${plistPath}`
+      : `missing: ${plistPath} — run "node dist/install-launchd.js install"`,
+  });
+
+  if (plistExists) {
+    const [nodePath, scriptPath] = extractProgramArguments(
+      readFileSync(plistPath, "utf-8")
+    );
+
+    const nodeOk = !!nodePath && existsSync(nodePath);
+    checks.push({
+      name: "node-path",
+      ok: nodeOk,
+      detail: nodeOk
+        ? `Node binary exists: ${nodePath}`
+        : `Node binary NOT found: ${nodePath ?? "(none in plist)"} — a "brew upgrade node" likely moved it. Re-run "node dist/install-launchd.js install" to re-point the plist.`,
+    });
+
+    const scriptOk = !!scriptPath && existsSync(scriptPath);
+    checks.push({
+      name: "monitor-script",
+      ok: scriptOk,
+      detail: scriptOk
+        ? `monitor script exists: ${scriptPath}`
+        : `monitor script NOT found: ${scriptPath ?? "(none in plist)"} — run "npm run build".`,
+    });
+
+    let loaded = false;
+    try {
+      execFileSync("launchctl", ["list", PLIST_NAME], { stdio: "ignore" });
+      loaded = true;
+    } catch {}
+    checks.push({
+      name: "launchd-loaded",
+      ok: loaded,
+      detail: loaded
+        ? `${PLIST_NAME} is loaded`
+        : `${PLIST_NAME} not in "launchctl list" — the job is not scheduled. Re-run install.`,
+    });
+  }
+
+  return { ok: checks.every((c) => c.ok), checks };
+}
+
 export function uninstallLaunchd(): void {
   const plistPath = getPlistPath();
   try {
@@ -160,7 +274,13 @@ if (isMain) {
     installLaunchd(scriptPath);
   } else if (action === "uninstall") {
     uninstallLaunchd();
+  } else if (action === "doctor") {
+    const report = doctor();
+    for (const c of report.checks) {
+      console.log(`${c.ok ? "✅" : "❌"} ${c.name}: ${c.detail}`);
+    }
+    process.exit(report.ok ? 0 : 1);
   } else {
-    console.log("Usage: install-launchd <install|uninstall>");
+    console.log("Usage: install-launchd <install|uninstall|doctor>");
   }
 }


### PR DESCRIPTION
## Problem

`install-launchd.ts` embedded `process.execPath` in the generated plist. `process.execPath` resolves symlinks, so under Homebrew it is the version-pinned Cellar path (e.g. `/opt/homebrew/Cellar/node/26.0.0/bin/node`). The next `brew upgrade node` deletes that directory, launchd can never spawn the monitor again, and the in-process heartbeat (`health.ts`) never fires. That is a silent death of the monitor, one layer below the failure class the heartbeat was built to catch.

## Fix

- **`resolveDurableNodePath(execPath)`**: when `execPath` sits under a Homebrew `/Cellar/`, prefer the stable `<brew-prefix>/bin/node` symlink (which Homebrew re-points on every upgrade) when it exists; otherwise fall back to `execPath` unchanged. Non-Homebrew paths (nvm, asdf, system) pass through untouched. `generatePlist` now defaults to this instead of raw `process.execPath`.
- **`doctor()` + `bounty-hunter doctor`**: a health check for the installed job. It verifies the plist exists, its Node binary and monitor-script paths still resolve, and the job is loaded in `launchctl list`. Exits non-zero on any failure, so it can feed an external watchdog. Also available as `node dist/install-launchd.js doctor`.

## Tests

Added coverage for `resolveDurableNodePath` (non-Homebrew pass-through, Cellar→symlink mapping, fallback when no symlink), `extractProgramArguments`, and `doctor` (missing plist, the brew-upgrade dead-node-path case, and the healthy case). Updated the existing default-node-path test. Full suite: 237 passing.

## Notes

- Only the repo source/template and docs are changed. Re-running `install` on an affected machine re-points a stale plist; no live launchd job is modified by this PR.
- Verified locally: on this Homebrew machine the generated plist now uses `/opt/homebrew/bin/node` and contains no `/Cellar/` path.